### PR TITLE
feat(injection): add configurable polling delay via INJECTION.delay_s…

### DIFF
--- a/Py4GW.ini
+++ b/Py4GW.ini
@@ -100,3 +100,5 @@ category = Gameplay
 subcategory = Overlays
 enabled = True
 
+[INJECTION]
+delay_seconds = 15

--- a/Py4GW_LauncherCompact.py
+++ b/Py4GW_LauncherCompact.py
@@ -174,6 +174,13 @@ class IniHandler:
 current_directory = os.getcwd()
 ini_file = "Py4GW.ini"
 ini_handler = IniHandler(ini_file)
+
+'''See more in this discord thread : https://discord.com/channels/1289955074298347625/1362926814820831232'''
+try:
+    injection_delay = ini_handler.read_float("INJECTION", "delay_seconds", 0.5)
+except Exception:
+    injection_delay = 0.5
+
 '''For Future Use'''
 mods_directory = os.path.join(current_directory, "Addons", "mods")
 os.makedirs(mods_directory, exist_ok=True)  # Create Addons/Mods if it doesn't exist
@@ -701,7 +708,7 @@ class GWLauncher:
                 log_history.append(f"Wait for GW Window - Error while waiting for GW window: {str(e)}")
                 return False
                 
-            time.sleep(0.5)
+            time.sleep(injection_delay)
             
             # Add progress indicator every 5 seconds
             elapsed = time.time() - start_time


### PR DESCRIPTION
## Description

This pull request adds a new configurable polling delay to the `wait_for_gw_window` method. Instead of the hard‑coded `time.sleep(0.5)`, the launcher now reads a `delay_seconds` value from an `[INJECTION]` section in `Py4GW.ini`. If the section or key is missing—or if the value is not a valid number—the code will fall back to the default 0.5 seconds. 

Original issue thread here : https://discord.com/channels/1289955074298347625/1362926814820831232

## Changes

- **Configuration**  
  - Introduce an `[INJECTION]` section in `Py4GW.ini` with a `delay_seconds` key.
  - After initializing `ini_handler`, read `delay_seconds` via `ini_handler.read_float("INJECTION", "delay_seconds", 0.5)` and store it in `injection_delay`.
- **Behavior**  
  - Replace the hard‑coded `time.sleep(0.5)` in `GWLauncher.wait_for_gw_window` with `time.sleep(injection_delay)`.
  - Default to 0.5 s if the INI section/key is missing or invalid.

## How to Test

1. In `Py4GW.ini`, add:
  ```ini
   [INJECTION]
   delay_seconds = 15
   ```
2. Launch the application and verify that the console’s polling log entries appear every 15 seconds.

3. Remove the [INJECTION] section or set delay_seconds to a non-numeric value, then restart and ensure the polling interval defaults back to 0.5 seconds.


This is still in WIP waiting for Azru feedback to make sure this is fixing his issue