### PR TITLE
Update combat.py, custom_skill.py, Agent.py, enum.py, Player.py, Routines.py & SkillManager.py

### DIFF
--- a/HeroAI/combat.py
+++ b/HeroAI/combat.py
@@ -62,7 +62,6 @@ SPIRIT_BUFF_MAP = {
     SpiritModelID.WINNOWING: Skill.GetID("Winnowing"),
 }
 
-
 class CombatClass:
     global MAX_SKILLS, custom_skill_data_handler
 

--- a/HeroAI/custom_skill.py
+++ b/HeroAI/custom_skill.py
@@ -2096,7 +2096,7 @@ class CustomSkillClass:
         skill.SkillType = SkillType.Skill.value
         skill.TargetAllegiance = Skilltarget.Self.value
         skill.Nature = SkillNature.Healing.value
-        skill.Conditions.LessLife = 0.75
+        skill.Conditions.LessLife = 0.9
         self.skill_data[skill.SkillID] = skill
 
         skill = self.CustomSkill()

--- a/Py4GWCoreLib/Agent.py
+++ b/Py4GWCoreLib/Agent.py
@@ -530,7 +530,7 @@ class Agent:
         return Agent.agent_instance(agent_id).living_agent.in_combat_stance
 
     @staticmethod
-    def IsAgressive(agent_id):
+    def IsAggressive(agent_id):
         """Check if the agent is attacking or casting."""
         if Agent.agent_instance(agent_id).living_agent.is_attacking or Agent.agent_instance(agent_id).living_agent.is_casting:
             return True

--- a/Py4GWCoreLib/Player.py
+++ b/Py4GWCoreLib/Player.py
@@ -192,7 +192,7 @@ class Player:
         return Player.player_instance().FormatChatMessage(message, r, g, b)
 
     @staticmethod
-    def ChangeTarget (agent_id):
+    def ChangeTarget(agent_id):
         """
         Purpose: Change the player's target.
         Args:

--- a/Py4GWCoreLib/Routines.py
+++ b/Py4GWCoreLib/Routines.py
@@ -27,8 +27,7 @@ class Routines:
                 if Agent.IsCasting(Player.GetAgentID()):
                     return False
                 return True
-                
-                
+
         class Map:
             @staticmethod
             def MapValid():
@@ -41,7 +40,7 @@ class Routines:
                 if Map.IsInCinematic():
                     return False
                 return True
-            
+
         class Inventory:
             @staticmethod
             def InventoryAndLockpickCheck():
@@ -54,10 +53,10 @@ class Routines:
                 if Effects.BuffExists(agent_id, skill_id) or Effects.EffectExists(agent_id, skill_id):
                     return True
                 return False
-            
+
         class Agents:
             @staticmethod
-            def InDanger(aggro_area=Range.Earshot):
+            def InDanger(aggro_area=Range.Earshot, aggressive_only = False):
                 from .Agent import Agent
                 from .Player import Player
                 from .AgentArray import AgentArray
@@ -65,6 +64,8 @@ class Routines:
                 enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Utils.Distance(Player.GetXY(), Agent.GetXY(agent_id)) <= aggro_area.value)
                 enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Agent.IsAlive(agent_id))
                 enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Player.GetAgentID() != agent_id)
+                if aggressive_only:
+                    enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Agent.IsAggressive(agent_id))
                 if len(enemy_array) > 0:
                     return True
                 return False
@@ -107,8 +108,6 @@ class Routines:
                 owner = Agent.GetItemAgentOwnerID(item_id)
                 return (owner == Player.GetAgentID()) or (owner == 0)
 
-
-            
         class Skills:
             @staticmethod
             def HasEnoughEnergy(agent_id, skill_id):
@@ -547,7 +546,7 @@ class Routines:
                 ConsoleLog(current_function, f"Still traveling... Waiting to arrive at: {Map.GetMapName(outpost_id)}.", Console.MessageType.Info)
 
             return False
-        
+
         @staticmethod
         def IsOutpostLoaded(log_actions=True):
             """
@@ -581,7 +580,7 @@ class Routines:
             from .Party import Party
             from .Map import Map
             
-            map_loaded =  Map.IsMapReady() and Map.IsExplorable() and Party.IsPartyLoaded()
+            map_loaded = Map.IsMapReady() and Map.IsExplorable() and Party.IsPartyLoaded()
             
             if log_actions:
                 if map_loaded:
@@ -630,7 +629,7 @@ class Routines:
             return Routines.Agents.GetNearestNPCXY(player_pos[0], player_pos[1], distance)
          
         @staticmethod
-        def GetFilteredEnemyArray(x,y,max_distance=4500.0):
+        def GetFilteredEnemyArray(x, y, max_distance=4500.0, aggressive_only = False):
             from .AgentArray import AgentArray
             from .Player import Player
             from .Agent import Agent
@@ -644,67 +643,69 @@ class Routines:
             enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Utils.Distance((x,y), Agent.GetXY(agent_id)) <= max_distance)
             enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Agent.IsAlive(agent_id))
             enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Player.GetAgentID() != agent_id)
+            if aggressive_only:
+                enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Agent.IsAggressive(agent_id))
             return enemy_array
                      
         @staticmethod
-        def GetNearestEnemy(max_distance=4500.0):
+        def GetNearestEnemy(max_distance=4500.0, aggressive_only = False):
             from .AgentArray import AgentArray
             from .Player import Player
             from .Py4GWcorelib import Utils
 
             player_pos = Player.GetXY()
-            enemy_array = Routines.Agents.GetFilteredEnemyArray(player_pos[0], player_pos[1], max_distance)
+            enemy_array = Routines.Agents.GetFilteredEnemyArray(player_pos[0], player_pos[1], max_distance, aggressive_only)
             enemy_array = AgentArray.Sort.ByDistance(enemy_array, player_pos)
             return Utils.GetFirstFromArray(enemy_array)
         
         @staticmethod
-        def GetNearestEnemyCaster(max_distance=4500.0):
+        def GetNearestEnemyCaster(max_distance=4500.0, aggressive_only = False):
             from .AgentArray import AgentArray
             from .Player import Player
             from .Agent import Agent
             from .Py4GWcorelib import Utils
 
             player_pos = Player.GetXY()
-            enemy_array = Routines.Agents.GetFilteredEnemyArray(player_pos[0], player_pos[1], max_distance)
+            enemy_array = Routines.Agents.GetFilteredEnemyArray(player_pos[0], player_pos[1], max_distance, aggressive_only)
             enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Agent.IsCaster(agent_id))
             enemy_array = AgentArray.Sort.ByDistance(enemy_array, player_pos)
             return Utils.GetFirstFromArray(enemy_array)
             
         @staticmethod
-        def GetNearestEnemyMartial(max_distance=4500.0):
+        def GetNearestEnemyMartial(max_distance=4500.0, aggressive_only = False):
             from .AgentArray import AgentArray
             from .Player import Player
             from .Agent import Agent
             from .Py4GWcorelib import Utils
 
             player_pos = Player.GetXY()
-            enemy_array = Routines.Agents.GetFilteredEnemyArray(player_pos[0], player_pos[1], max_distance)
+            enemy_array = Routines.Agents.GetFilteredEnemyArray(player_pos[0], player_pos[1], max_distance, aggressive_only)
             enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Agent.IsMartial(agent_id))
             enemy_array = AgentArray.Sort.ByDistance(enemy_array, player_pos)
             return Utils.GetFirstFromArray(enemy_array)   
         
         @staticmethod
-        def GetNearestEnemyMelee(max_distance=4500.0):
+        def GetNearestEnemyMelee(max_distance=4500.0, aggressive_only = False):
             from .AgentArray import AgentArray
             from .Player import Player
             from .Agent import Agent
             from .Py4GWcorelib import Utils
 
             player_pos = Player.GetXY()
-            enemy_array = Routines.Agents.GetFilteredEnemyArray(player_pos[0], player_pos[1], max_distance)
+            enemy_array = Routines.Agents.GetFilteredEnemyArray(player_pos[0], player_pos[1], max_distance, aggressive_only)
             enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Agent.IsMelee(agent_id))
             enemy_array = AgentArray.Sort.ByDistance(enemy_array, player_pos)
             return Utils.GetFirstFromArray(enemy_array)
         
         @staticmethod
-        def GetNearestEnemyRanged(max_distance=4500.0):
+        def GetNearestEnemyRanged(max_distance=4500.0, aggressive_only = False):
             from .AgentArray import AgentArray
             from .Player import Player
             from .Agent import Agent
             from .Py4GWcorelib import Utils
 
             player_pos = Player.GetXY()
-            enemy_array = Routines.Agents.GetFilteredEnemyArray(player_pos[0], player_pos[1], max_distance)
+            enemy_array = Routines.Agents.GetFilteredEnemyArray(player_pos[0], player_pos[1], max_distance, aggressive_only)
             enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Agent.IsRanged(agent_id))
             enemy_array = AgentArray.Sort.ByDistance(enemy_array, player_pos)
             return Utils.GetFirstFromArray(enemy_array)
@@ -824,6 +825,10 @@ class Routines:
             gadget_array = AgentArray.Sort.ByDistance(gadget_array,Player.GetXY())
             for agent_id in gadget_array:
                 if Agent.GetGadgetID(agent_id) == 9: #9 is the ID for a Hidden Stash (Pre-Searing)
+                    return agent_id
+                if Agent.GetGadgetID(agent_id) == 69: #69 is the ID for a chest
+                    return agent_id
+                if Agent.GetGadgetID(agent_id) == 4579: #4579 is the ID for a chest
                     return agent_id
                 if Agent.GetGadgetID(agent_id) == 8141: #8141 is the ID for a chest
                     return agent_id
@@ -965,11 +970,10 @@ class Routines:
 
             return best_target
 
-
     #region Movement
     class Movement:
         @staticmethod
-        def FollowPath(path_handler,follow_handler, log_actions=False):
+        def FollowPath(path_handler, follow_handler, log_actions=False):
             """
             Purpose: Follow a path using the path handler and follow handler objects.
             Args:
@@ -977,12 +981,11 @@ class Routines:
                 follow_handler (FollowXY): The FollowXY object for moving to waypoints.
             Returns: None
             """
-            
+
             follow_handler.update()
 
             if follow_handler.is_following():
                 return
-
 
             point = path_handler.advance()
             if point is not None:
@@ -993,7 +996,6 @@ class Routines:
         @staticmethod
         def IsFollowPathFinished(path_handler,follow_handler):
             return path_handler.is_finished() and follow_handler.has_arrived()
-
 
         class FollowXY:
             def __init__(self, tolerance=100):
@@ -1009,13 +1011,11 @@ class Routines:
                 self.wait_timer = Timer()  # Timer to track waiting after issuing move command
                 self.wait_timer_run_once = True
 
-
             def calculate_distance(self, pos1, pos2):
                 """
                 Calculate the Euclidean distance between two points.
                 """
                 return Utils.Distance(pos1, pos2)
-
 
             def move_to_waypoint(self, x=0, y=0, tolerance=None, use_action_queue = False):
                 """
@@ -1116,7 +1116,6 @@ class Routines:
                 Check if the player has arrived at the current waypoint.
                 """
                 return self.arrived
-
 
         class PathHandler:
             def __init__(self, coordinates):
@@ -1236,8 +1235,7 @@ class Routines:
                 target_id = Player.GetTargetID()
                 if target_id != 0:
                     Routines.Sequential.Player.InteractAgent(target_id)
-                    
-                     
+
             @staticmethod
             def SendDialog(dialog_id:str):
                 from .Player import Player
@@ -1262,8 +1260,7 @@ class Routines:
                 sleep(0.3)
                 if log:
                     ConsoleLog("SendChatCommand", f"Sending chat command {command}", Console.MessageType.Info)
-               
-            
+
             @staticmethod
             def Move(x:float, y:float, log=False):
                 from .Player import Player
@@ -1272,7 +1269,7 @@ class Routines:
                 sleep(0.1)
                 if log:
                     ConsoleLog("MoveTo", f"Moving to {x}, {y}", Console.MessageType.Info)
-                     
+
         class Movement:
             @staticmethod
             def FollowPath(path_points: List[Tuple[float, float]], custom_exit_condition:Callable[[], bool] =lambda: False, tolerance:float=150):
@@ -1306,7 +1303,6 @@ class Routines:
                             break  # Arrived at this waypoint, move to next
 
                         sleep(0.5)
-                        
 
         class Skills:
             @staticmethod
@@ -1343,8 +1339,7 @@ class Routines:
                 if log:
                     ConsoleLog("CastSkillID", f"Cast {Skill.GetName(skill_id)}, slot: {SkillBar.GetSlotBySkillID(skill_id)}", Console.MessageType.Info)
                 return True
-            
-            
+
             @staticmethod
             def CastSkillSlot(slot:int,extra_condition=True, log=False):
                 from .Skillbar import SkillBar
@@ -1377,8 +1372,7 @@ class Routines:
                 ActionQueueManager().AddAction("ACTION",Party.SetHardMode)
                 sleep(0.5)
                 ConsoleLog("SetHardMode", "Hard mode set.", Console.MessageType.Info, log=log)
-                
-                                
+
             @staticmethod
             def TravelToOutpost(outpost_id, log=False):
                 """
@@ -1486,6 +1480,7 @@ class Routines:
                 agent_id = Routines.Sequential.Agents.GetAgentIDByName(agent_name)
                 if agent_id != 0:
                     Routines.Sequential.Agents.ChangeTarget(agent_id)
+
             @staticmethod
             def TargetNearestNPC(distance:float = 4500.0):
                 nearest_npc = Routines.Agents.GetNearestNPC(distance)

--- a/Py4GWCoreLib/enums.py
+++ b/Py4GWCoreLib/enums.py
@@ -27,13 +27,47 @@ class Range(Enum):
 #endregion
 #region ServerRegion
 class ServerRegion(IntEnum):
-    International = 0
-    America = 1
-    Korea = 2
-    Europe = 3
-    China = 4
-    Japan = 5
-    Unknown = 6
+    International = -2
+    America = 0
+    Korea = 1
+    Europe = 2
+    China = 3
+    Japan = 4
+    Unknown = 6 # left  untouched if anyone is using this
+
+#endregion
+#region ServerRegionName
+ServerRegionName = {
+    ServerRegion.International.value: 'International',
+    ServerRegion.America.value: 'America',
+    ServerRegion.Korea.value: 'Korea',
+    ServerRegion.Europe.value: 'Europe',
+    ServerRegion.China.value: 'Traditional Chinese',
+    ServerRegion.Japan.value: 'Japanese',
+}
+       
+#endregion
+#region ServerLanguage
+class ServerLanguage(IntEnum):
+    English = 0
+    French = 2
+    German = 3
+    Italian = 4
+    Spanish = 5
+    Polish = 9
+    Russian = 10
+
+#endregion
+#region ServerLanguageName
+ServerLanguageName = {
+    ServerLanguage.English.value: 'English',
+    ServerLanguage.French.value: 'French',
+    ServerLanguage.German.value: 'German',
+    ServerLanguage.Italian.value: 'Italian',
+    ServerLanguage.Spanish.value: 'Spanish',
+    ServerLanguage.Polish.value: 'Polish',
+    ServerLanguage.Russian.value: 'Russian',
+}
 
 #endregion
 #region Language
@@ -1083,6 +1117,7 @@ explorables = {
     145: "The Catacombs",
     146: "Lakeside County",
     147: "The Northlands",
+    148: "Ascalon City (pre-Searing)",
     149: "Ascalon Academy",
     151: "Ascalon Academy",
     160: "Green Hills County",
@@ -2190,8 +2225,7 @@ class SpiritModelID(IntEnum):
     WINDS = 2884
 
 #region Menagerie
-#PET_MODEL    
-    
+#PET_MODEL
 class PetModelID(IntEnum):
     #charmable animals
     MELANDRUS_STALKER_WILD = 1345


### PR DESCRIPTION
This will add the ability to toggle only fighting aggressive enemies with 'Autocombat' in ''SkillManager.py', fix the enum 'ServerRegion' and also fix a spelling mistake in 'IsAggressive' in 'Agent.py':

combat.py:
Removed a 'line break'

custom_skill.py:
Changed 'Troll Urgent' 'skill.Conditions.LessLife' to '0.9 from '0.75'

Agent.py:
Fixed the spelling of 'IsAggressive'

enums.py:
Fixed enum 'ServerRegion' values where wrong
Added 'ServerRegionName' table
Added 'ServerLanguage' enum it differs from 'Language'
Added '148: "Ascalon City (pre-Searing)",' to 'explorables' table
Removed some 'spaces' and a 'line break' from '#PET_MODEL'

Player.py:
Removed a 'space' in 'ChangeTarget'

Routines.py:
Added the ability to filter out none aggressive enemies, enabling the ability to utilize this in 'Autocombat' in 'SkillManager.py'
Added 'aggressive_only' bool and check to 'InDanger', 'GetFilteredEnemyArray', 'GetNearestEnemy', 'GetNearestEnemyCaster*, 'GetNearestEnemyMartial', 'GetNearestEnemyMelee' & 'GetNearestEnemyRanged', making it possible to filter out none aggressive enemies
Added two more chest GadgetID's to 'GetNearestChest', would be great to have the names here too to make sure we get them all sorted (the two new haven't got names will update when possible)
Removed some 'spaces' and 'line breaks'

SkillManager.py:
Added the ability to only fight aggressive enemies
Added 'self.aggressive_enemies_only' to '__init__' in 'Autocombat'
Added function 'SetAggressiveEnemiesOnly' to ''Autocombat' adding the ability to Toggle only fighting aggressive enemies, takes a bool, enabling / disabling only fighting aggressive enemies
Added 'self.aggressive_only' bool to 'InAggro', 'GetAppropiateTarget' and 'ChooseTarget' in 'SkillManager'
Removed 'spaces' and 'line breaks'