### PR TITLE
fix transition timer perma reset

### DIFF
--- a/Py4GWCoreLib/Py4GWcorelib.py
+++ b/Py4GWCoreLib/Py4GWcorelib.py
@@ -1220,8 +1220,9 @@ class FSM:
             """Run the state's block of code. If `run_once` is True, run it only once."""
             if not self.run_once or not self.executed:
                 self.execute_fn()
-                self.executed = True  # Mark execution as complete if run_once is True
-                self.reset_transition_timer()  # Reset the timer
+                if not self.executed:  # Only reset timer on first execution
+                    self.reset_transition_timer()
+                self.executed = True
 
         def can_exit(self):
             """


### PR DESCRIPTION
Adjust def execute(self) in FSM class to not reset transition timer on every execution.
This fixes the a bug where if run_once = False and transition_delay_ms > 0 looped permanently.