### PR TITLE
Fix aftercast timing and improve Heroic Refrain usage logic

### DIFF
--- a/Bots/cof_bone_farmer.py
+++ b/Bots/cof_bone_farmer.py
@@ -287,7 +287,7 @@ class Combat:
 
         activation = Skill.Data.GetActivation(skill_id)
         aftercast = Skill.Data.GetAftercast(skill_id)    
-        return max(activation*1000 + aftercast*1000 + Py4GW.PingHandler().GetCurrentPing() + 50,500)
+        return max(activation*1000 + aftercast*750 + Py4GW.PingHandler().GetCurrentPing() + 50,500)
 
 class ProcessInventory:
     def CheckSlots(self):

--- a/HeroAI/combat.py
+++ b/HeroAI/combat.py
@@ -145,6 +145,7 @@ class CombatClass:
         self.weakness = Skill.GetID("Weakness")
         self.comfort_animal = Skill.GetID("Comfort_Animal")
         self.heal_as_one = Skill.GetID("Heal_as_One")
+        self.heroic_refrain = Skill.GetID("Heroic_Refrain")
         
     def Update(self, cached_data):
         self.in_aggro = cached_data.in_aggro
@@ -327,6 +328,10 @@ class CombatClass:
         
         nearest_enemy = Routines.Agents.GetNearestEnemy(self.get_combat_distance())
         lowest_ally = TargetLowestAlly(filter_skill_id=self.skills[slot].skill_id)
+
+        if self.skills[slot].skill_id == self.heroic_refrain:
+            if not self.HasEffect(Player.GetAgentID(), self.heroic_refrain):
+                return Player.GetAgentID()
 
         if target_allegiance == Skilltarget.Enemy:
             v_target = self.GetPartyTarget()
@@ -952,7 +957,7 @@ class CombatClass:
         self.in_casting_routine = True
 
         self.aftercast = Skill.Data.GetActivation(skill_id) * 1000
-        self.aftercast += Skill.Data.GetAftercast(skill_id) * 1000
+        self.aftercast += Skill.Data.GetAftercast(skill_id) * 750
         #self.aftercast += 150 #manually setting a 50ms delay to test issues with pinghandler
         self.aftercast += self.ping_handler.GetCurrentPing()
 

--- a/Py4GWCoreLib/SkillManager.py
+++ b/Py4GWCoreLib/SkillManager.py
@@ -947,7 +947,7 @@ class SkillManager:
             self.in_casting_routine = True
 
             aftercast = Skill.Data.GetActivation(skill_id) * 1000
-            aftercast += Skill.Data.GetAftercast(skill_id) * 1000
+            aftercast += Skill.Data.GetAftercast(skill_id) * 750
             aftercast += self.ping_handler.GetCurrentPing()
             self.aftercast_timer.SetThrottleTime(aftercast)
             self.aftercast_timer.Reset()

--- a/Widgets/HeroHelper.py
+++ b/Widgets/HeroHelper.py
@@ -484,7 +484,7 @@ class Helper:
         activation = Skill.Data.GetActivation(skill_id)
         aftercast = Skill.Data.GetAftercast(skill_id)
         ping = Py4GW.PingHandler().GetCurrentPing()
-        return max(activation * 1000 + aftercast * 1000 + ping + 50, 500)
+        return max(activation * 1000 + aftercast * 750 + ping + 50, 500)
     
     @staticmethod
     def smartcast_hero_skill(skill_id, min_enemies=0, enemy_range_check=None,


### PR DESCRIPTION
This PR includes the following changes:

Adjusted Aftercast Delay Calculation
Related to the wiki: [Aftercast Delay](https://wiki.guildwars.com/wiki/Aftercast_delay)
The aftercast delay is 3/4 seconds (750ms), not 1 second when Skill.Data.GetAftercast(skill_id) = 1.
➝ Changed aftercast * 1000 to aftercast * 750 to reflect this.

Improved Heroic Refrain Behavior

Added Heroic_Refrain in __init__.

Added a condition for it in GetAppropriateTarget.
➝ This allows the player who possesses the Heroic Refrain skill to cast it on themselves first, gaining the stat bonus before using it on allies.