### PR TITLE
Add check for missing account name (not registered)

### DIFF
--- a/Bots/Rollerbeetle Racing.py
+++ b/Bots/Rollerbeetle Racing.py
@@ -407,7 +407,9 @@ def DrawWindow():
             else:
                 # Disable the "Start Bot" button if the current map ID is not 467 and the player does not have the outpost unlocked
                 if not Map.GetMapID() == ROLLERBEETLE_RACING_OUTPOST_ID and not Map.GetIsMapUnlocked(ROLLERBEETLE_RACING_OUTPOST_ID):
-                    PyImGui.text("Go to Rollerbeetle Racing Outpost")
+                    PyImGui.text("Go to Rollerbeetle Racing Outpost first!\nVia Kamadan, Shing Jea, LA, GToB")
+                elif Player.GetAccountName() == "":
+                    PyImGui.text("Account is not registered yet!\nTalk to Tolkano [Tournament]")
                 else:
                     if PyImGui.button("Start Bot"):
                         ResetEnvironment()


### PR DESCRIPTION
Add some text to know how to get there if they outpost isn't unlocked:
![image](https://github.com/user-attachments/assets/8e6c2dda-8f67-487e-bc05-e1d9d6353a38)

Add text if account isn't registered (must be registered before bot can be started):
![image](https://github.com/user-attachments/assets/64969f91-a242-42f3-819a-3c474609a582)
