### PR TITLE
Better Shout & Stance managment

### DIFF
--- a/HeroAI/custom_skill.py
+++ b/HeroAI/custom_skill.py
@@ -56,6 +56,7 @@ class CustomSkillClass:
                 self.PartyWideArea = 0
                 self.UniqueProperty = False
                 self.IsOutOfCombat = False
+                self.IgnoreEffectCheck = False
 
     class CustomSkill:
         def __init__(self):
@@ -858,6 +859,7 @@ class CustomSkillClass:
         skill.SkillType = SkillType.Shout.value
         skill.TargetAllegiance = Skilltarget.Self.value
         skill.Nature = SkillNature.Buff.value
+        skill.Conditions.IgnoreEffectCheck = True
         self.skill_data[skill.SkillID] = skill
 
         skill = self.CustomSkill()


### PR DESCRIPTION
# Improvements to handling Shout and Stance skills

This PR introduces several important improvements to skill management, particularly for Shouts and Stances.

## Main changes

### 1. Added `IgnoreEffectCheck` option

Added a new `IgnoreEffectCheck` attribute to the `CastConditions` class in `custom_skill.py`. This option allows specifying that certain skills should be used as soon as they are recharged, without checking if their effect is still active on the target.

```python
# In CastConditions.__init__
self.IgnoreEffectCheck = False  # False by default
```

### 2. Improved effect verification system

In the `IsReadyToCast` method, we modified the effect checking to take into account the `IgnoreEffectCheck` option:

```python
# Enhanced effect checking
ignore_effect = getattr(self.skills[slot].custom_skill_data.Conditions, "IgnoreEffectCheck", False)
if self.HasEffect(v_target, self.skills[slot].skill_id) and not ignore_effect:
    self.in_casting_routine = False
    return False, v_target
```

### 3. Support for Shouts and Stances during casting and when knocked down

Added special logic to allow using Shouts and Stances even while the character is casting another skill or when knocked down:

```python
# Check if the skill is a shout or stance
is_shout = self.skills[slot].custom_skill_data.SkillType == SkillType.Shout.value
is_stance = self.skills[slot].custom_skill_data.SkillType == SkillType.Stance.value
is_knocked_down = Agent.IsKnockedDown(Player.GetAgentID())

# If it's not a shout or stance, standard checks
if not is_shout and not is_stance and Agent.IsCasting(Player.GetAgentID()):
    self.in_casting_routine = False
    return False, v_target
```

### 4. Restriction for Shouts and Stances out of combat

In the `IsOOCSkill` method, we added logic to avoid using Shouts and Stances out of combat:

```python
# Don't use Chant or Stance when Out Of Combat
if(skill_type == SkillType.Chant.value or 
   skill_type == SkillType.Stance.value
):
    return False
```

### 5. Application for a specific skill

We enabled the `IgnoreEffectCheck` option for the "To_the_Limit" skill:

```python
skill = self.CustomSkill()
skill.SkillID = Skill.GetID("To_the_Limit")
skill.SkillType = SkillType.Shout.value
skill.TargetAllegiance = Skilltarget.Self.value
skill.Nature = SkillNature.Buff.value
skill.Conditions.IgnoreEffectCheck = True  # Enable the option
self.skill_data[skill.SkillID] = skill
```

## Benefits of these changes

1. **Better flexibility**: Allows customizing behavior for each skill
2. **Increased responsiveness for Shouts**: Shouts like "To the Limit" can be used as soon as they are recharged
3. **More consistent behavior with the game**: Shouts and Stances can be used during casting or when knocked down, as in the original game
4. **Energy conservation**: Avoids using Shouts and Stances out of combat when not necessary

This PR globally improves automated combat decision-making, making it more faithful to the original game mechanics and more efficient for certain types of skills.