### PR TITLE
refactor(widget_manager): widget config scope to fix circular reference and fix floating button drag logic

### DIFF
--- a/Widgets/widget_manager/config_scope.py
+++ b/Widgets/widget_manager/config_scope.py
@@ -1,0 +1,5 @@
+# config_scope.py
+selected_settings_scope = 0  # 0 = Global, 1 = Account
+
+def use_account_settings():
+    return selected_settings_scope == 1

--- a/Widgets/widget_manager/handler.py
+++ b/Widgets/widget_manager/handler.py
@@ -232,6 +232,9 @@ class WidgetHandler:
             path = os.path.join(self.widgets_path, file)
             try:
                 module = self.load_widget(path)
+                if not module:
+                    ConsoleLog("WidgetHandler", f"Skipped widget: {name} (module load failed)", Py4GW.Console.MessageType.Warning)
+                    continue
                 enabled = self.widget_data_cache.get(name, {}).get("enabled", True)
                 self.widgets[name] = {"module": module, "enabled": enabled, "configuring": False}
                 ConsoleLog("WidgetHandler", f"Loaded widget: {name}", Py4GW.Console.MessageType.Info)

--- a/Widgets/widget_manager/main.py
+++ b/Widgets/widget_manager/main.py
@@ -8,36 +8,35 @@ from .ui_floating_menu import draw_floating_menu
 from .ui_embedded_config import draw_embedded_widget_config
 from .ui_quickdock import quick_dock_menu
 from .ui_old_menu import draw_old_widget_ui
+from .settings_io import initialize_settings
 
 def main():
     try:
+        # sort_frame = UIManager.IsWindowVisible(UIManager.GetChildFrameID(2232987037,[0]))
+        # menu_frame = UIManager.IsWindowVisible(UIManager.GetFrameIDByHash(1144678641))
+        
+        # if ((sort_frame and menu_frame) or ((Map.GetDescriptionID() == 39684 and Map.GetMapID() == 514) or Map.IsInCinematic())):
+        #     return
+        
         if not state.initialized:
             handler.discover_widgets()
             state.initialized = True
 
-        if (not handler.account_initialized and 
-            not Map.IsMapLoading() and 
-            not Map.IsInCinematic() and 
-            not Player.InCharacterSelectScreen() and 
+        if (not handler.account_initialized and
+            not Player.InCharacterSelectScreen() and
             Party.IsPartyLoaded()):
             handler._initialize_account_settings()
             handler._initialize_account_config()
+            initialize_settings()
 
-
-        # if (Map.IsMapLoading() and Party.IsPartyLoaded()) or Map.IsInCinematic():
-        #     return
-        
         if state.old_menu:
             draw_old_widget_ui()
 
-        if (state.enable_quick_dock and
-            not Map.IsMapLoading() and 
-            not Map.IsInCinematic() and 
-            not Player.InCharacterSelectScreen() and 
-            Party.IsPartyLoaded()):
+        if state.enable_quick_dock:
             quick_dock_menu()
-        
-        draw_floating_menu()
+
+        draw_floating_menu() 
+                   
         draw_embedded_widget_config()
         
         if state.enable_all:

--- a/Widgets/widget_manager/settings_io.py
+++ b/Widgets/widget_manager/settings_io.py
@@ -1,5 +1,6 @@
 from Py4GWCoreLib import *
 from .handler import handler
+from .config_scope import use_account_settings
 from . import state
 
 def write_settings_to_ini():
@@ -31,7 +32,7 @@ def restore_global_defaults():
 
 def save_all_settings(to_account: bool = False):
     # Always save this to account scope, regardless of flag
-    handler._write_account_setting("WidgetManager", "use_account_settings", str(state.use_account_settings))
+    handler._write_account_setting("WidgetManager", "use_account_settings", str(use_account_settings()))
 
     wm_keys = {
         "enable_all": state.enable_all,
@@ -69,79 +70,21 @@ def save_all_settings(to_account: bool = False):
         for k, v in entries.items():
             handler._write_setting(name, k, str(v), to_account=to_account, force=True)
 
-# def save_account_settings():
-#     wm_keys = {
-#         "enable_all": state.enable_all,
-#         "old_menu": state.old_menu,
-#         "use_account_settings": str(state.use_account_settings),
-#     }
-#     for k, v in wm_keys.items():
-#         handler._write_account_setting("WidgetManager", k, f"{v}")
-
-#     dock_keys = {
-#         "enable_quick_dock": state.enable_quick_dock,
-#         "width": state.quick_dock_width,
-#         "height": state.quick_dock_height,
-#         "offset_y": state.quick_dock_offset_y,
-#         "edge": state.quick_dock_edge[0],
-#         "unlocked": state.quick_dock_unlocked,
-#         "buttons_per_row": state.buttons_per_row
-#     }
-#     for k, v in dock_keys.items():
-#         handler._write_account_setting("QuickDock", k, f"{v}")
-
-#     for i, key in enumerate(("r", "g", "b", "a")):
-#         handler._write_account_setting("QuickDockColor", key, f"{state.quick_dock_color[i]}")
-
-#     for name, widget in handler.widgets.items():
-#         data = handler.widget_data_cache.get(name, {})
-#         for k, v in {
-#             "enabled": widget.get("enabled", False),
-#             "category": data.get("category", "Miscellaneous"),
-#             "subcategory": data.get("subcategory", "Others"),
-#             "icon": data.get("icon", "ICON_CIRCLE"),
-#             "quickdock": data.get("quickdock", False)
-#         }.items():
-#             handler._write_setting(name, k, str(v), to_account=True, force=True)
-
-# def save_global_settings():
-#     wm_keys = {
-#         "enable_all": state.enable_all,
-#         "old_menu": state.old_menu,
-#     }
-#     for k, v in wm_keys.items():
-#         handler._write_global_setting("WidgetManager", k, f"{v}")
-
-#     dock_keys = {
-#         "enable_quick_dock": state.enable_quick_dock,
-#         "width": state.quick_dock_width,
-#         "height": state.quick_dock_height,
-#         "offset_y": state.quick_dock_offset_y,
-#         "edge": state.quick_dock_edge[0],
-#         "unlocked": state.quick_dock_unlocked,
-#         "buttons_per_row": state.buttons_per_row
-#     }
-#     for k, v in dock_keys.items():
-#         handler._write_global_setting("QuickDock", k, f"{v}")
-
-#     for i, key in enumerate(("r", "g", "b", "a")):
-#         handler._write_global_setting("QuickDockColor", key, f"{state.quick_dock_color[i]}")
-
-#     for name, widget in handler.widgets.items():
-#         data = handler.widget_data_cache.get(name, {})
-#         handler._write_global_setting(name, "enabled", f"{widget.get('enabled', False)}")
-#         handler._write_global_setting(name, "quickdock", str(data.get("quickdock", False)))
-
 def initialize_settings():
-    if state.selected_settings_scope == 1:
+    use_account = handler._read_setting_bool("WidgetManager", "use_account_settings", True, force_account=True)
+    from . import config_scope
+    config_scope.selected_settings_scope = 1 if use_account else 0
+
+    if use_account:
         load_account_settings()
     else:
         load_global_settings()
 
 def load_account_settings():
+    from . import config_scope
     state.enable_all = handler._read_setting_bool("WidgetManager", "enable_all", False, force_account=True)
     state.old_menu = handler._read_setting_bool("WidgetManager", "old_menu", True, force_account=True)
-    state.use_account_settings = handler._read_setting_bool("WidgetManager", "use_account_settings", True, force_account=True)
+    config_scope.selected_settings_scope = 1 if handler._read_setting_bool("WidgetManager", "use_account_settings", True, force_account=True) else 0
 
     state.old_menu_window_pos = (
         handler._read_setting_int("WidgetManager", "omx", 100, force_account=True),
@@ -165,9 +108,10 @@ def load_account_settings():
     ]
     
 def load_global_settings():
+    from . import config_scope
     state.enable_all = handler._read_setting_bool("WidgetManager", "enable_all", False, force_global=True)
     state.old_menu = handler._read_setting_bool("WidgetManager", "old_menu", True, force_global=True)
-    state.use_account_settings = handler._read_setting_bool("WidgetManager", "use_account_settings", True, force_global=True)
+    config_scope.selected_settings_scope = 1 if handler._read_setting_bool("WidgetManager", "use_account_settings", True, force_account=True) else 0
 
     state.old_menu_window_pos = (
         handler._read_setting_int("WidgetManager", "omx", 100, force_global=True),

--- a/Widgets/widget_manager/state.py
+++ b/Widgets/widget_manager/state.py
@@ -27,6 +27,7 @@ quick_dock_color = [
     handler._read_setting_float("QuickDockColor", "b", 1.0),
     handler._read_setting_float("QuickDockColor", "a", 1.0),
 ]
+quick_dock_hovering_button = False
 
 # Ui Elements
 selected_widget = ""

--- a/Widgets/widget_manager/state.py
+++ b/Widgets/widget_manager/state.py
@@ -1,5 +1,6 @@
 from Py4GWCoreLib import *
 from .handler import handler
+from .config_scope import selected_settings_scope, use_account_settings
 
 module_name = "WidgetManager"
 
@@ -8,9 +9,8 @@ enable_all = handler._read_setting_bool("WidgetManager", "enable_all", False)
 old_enable_all = enable_all
 old_menu = handler._read_setting_bool("WidgetManager", "old_menu", False)
 initialized = False
-use_account_settings = handler._read_setting_bool("WidgetManager", "use_account_settings", False)
-selected_settings_scope = int(use_account_settings)
 settings_scope_options = ["Global.ini", "Account.ini"]
+
 show_config_window = False
 
 # QuickDock persistent config
@@ -47,6 +47,7 @@ floating_drag_locked = handler._read_setting_bool("FloatingMenu", "floating_drag
 is_dragging_floating_button = False
 floating_button_offset = (0, 0)
 hovering_floating_button = False
+focused_floating_button = False
 floating_menu_pos = (20.0, 100.0)
 floating_district_pos = (20.0, 100.0)
 floating_skill_pos = (20.0, 100.0)
@@ -96,4 +97,4 @@ write_timer.Start()
 
 menu_write_timer = Timer()
 write_timer.Start()
-
+    

--- a/Widgets/widget_manager/state.py
+++ b/Widgets/widget_manager/state.py
@@ -1,6 +1,5 @@
 from Py4GWCoreLib import *
 from .handler import handler
-from .config_scope import selected_settings_scope, use_account_settings
 
 module_name = "WidgetManager"
 

--- a/Widgets/widget_manager/ui_config_sections.py
+++ b/Widgets/widget_manager/ui_config_sections.py
@@ -1,6 +1,7 @@
 from Py4GWCoreLib import *
 from . import state
 from .handler import handler
+from .config_scope import use_account_settings
 from .settings_io import load_account_settings, load_global_settings, save_all_settings, restore_global_defaults
 
 def draw_centered_checkbox(label: str, value: bool) -> bool:
@@ -40,7 +41,7 @@ def draw_floating_menu_config():
         index = PyImGui.combo("##menuloc", index, state.floating_attachment_options)
         if index != state.floating_attachment_index:
             state.floating_attachment_index = index
-            handler._write_setting("FloatingMenu", "floating_attachment_index", str(index), to_account=state.use_account_settings)
+            handler._write_setting("FloatingMenu", "floating_attachment_index", str(index), to_account=use_account_settings())
             
         if state.floating_attachment_index == 3:
             PyImGui.spacing()
@@ -58,7 +59,7 @@ def draw_floating_menu_config():
         ImGui.show_tooltip("Overrides default floating button colors with custom values")
         if prev_enabled != state.floating_custom_colors_enabled:
             state.floating_custom_colors_enabled = prev_enabled
-            handler._write_setting("FloatingMenu", "use_custom_colors", str(state.floating_custom_colors_enabled), to_account=state.use_account_settings)
+            handler._write_setting("FloatingMenu", "use_custom_colors", str(state.floating_custom_colors_enabled), to_account=use_account_settings())
         
         if state.floating_custom_colors_enabled:
             for label, key in [("Base", "base"), ("Hover", "hover"), ("Active", "active"), ("Border", "border")]:
@@ -69,9 +70,10 @@ def draw_floating_menu_config():
                 if list(new_col) != state.floating_custom_colors[key]:
                     state.floating_custom_colors[key] = new_col
                     for i, ch in zip("rgba", new_col):
-                        handler._write_setting("FloatingMenu", f"{key}_{i}", ch, to_account=state.use_account_settings)
+                        handler._write_setting("FloatingMenu", f"{key}_{i}", ch, to_account=use_account_settings())
 
 def draw_account_widget_config():
+    from . import config_scope
     PyImGui.spacing()
     PyImGui.text("Widget Settings")
     PyImGui.separator()
@@ -84,21 +86,21 @@ def draw_account_widget_config():
     PyImGui.same_line(0, -1)
     PyImGui.set_cursor_pos(x + 160, y)
     PyImGui.set_next_item_width(PyImGui.get_content_region_avail()[0])
-    prev_scope = state.selected_settings_scope
-    state.selected_settings_scope = PyImGui.combo(
+    prev_scope = config_scope.selected_settings_scope
+    config_scope.selected_settings_scope = PyImGui.combo(
         "##settings_scope",
-        state.selected_settings_scope,
+        config_scope.selected_settings_scope,
         state.settings_scope_options
     )
-    state.use_account_settings = bool(state.selected_settings_scope)
 
-    if state.selected_settings_scope != prev_scope:
-        handler._write_account_setting("WidgetManager", "use_account_settings", str(state.use_account_settings))
-        if state.use_account_settings:
+    if config_scope.selected_settings_scope != prev_scope:
+        handler._write_account_setting("WidgetManager", "use_account_settings", str(use_account_settings()))
+        if use_account_settings:
             load_account_settings()
         else:
             load_global_settings()
         handler.discover_widgets()
+    
     ImGui.show_tooltip("Determines whether to load and save settings globally or per account")
 
     PyImGui.spacing()
@@ -179,7 +181,7 @@ def draw_quick_dock_config():
     enable_qd = draw_centered_checkbox(label, state.enable_quick_dock)
     if enable_qd != state.enable_quick_dock:
         state.enable_quick_dock = enable_qd
-        handler._write_setting("QuickDock", "enable_quick_dock", str(enable_qd), to_account=state.use_account_settings)
+        handler._write_setting("QuickDock", "enable_quick_dock", str(enable_qd), to_account=use_account_settings())
     ImGui.show_tooltip("Enable or Disbale the Widget Dock on the edge of the screen")
     
     PyImGui.spacing()
@@ -195,7 +197,7 @@ def draw_quick_dock_config():
     if list(new_color[:3]) != state.quick_dock_color[:3]:
         state.quick_dock_color[0:3] = new_color[0:3]
         for i, key in enumerate(("r", "g", "b")):
-            handler._write_setting("QuickDockColor", key, f"{state.quick_dock_color[i]}", to_account=state.use_account_settings)
+            handler._write_setting("QuickDockColor", key, f"{state.quick_dock_color[i]}", to_account=use_account_settings())
      
     PyImGui.spacing() 
     label = "Quick Dock Transparency:"
@@ -208,33 +210,33 @@ def draw_quick_dock_config():
     alpha = PyImGui.slider_float("Quick Dock Transparency", state.quick_dock_color[3], 0.0, 1.0)
     if alpha != state.quick_dock_color[3]:
         state.quick_dock_color[3] = alpha
-        handler._write_setting("QuickDockColor", "a", f"{alpha}", to_account=state.use_account_settings)
+        handler._write_setting("QuickDockColor", "a", f"{alpha}", to_account=use_account_settings())
     
     PyImGui.spacing()
     new_width = draw_labeled_slider("Quick Dock Width:", "##rwidth", state.quick_dock_width, 4, 50)
     if new_width != state.quick_dock_width:
         state.quick_dock_width = new_width
-        handler._write_setting("QuickDock", "width", str(state.quick_dock_width), to_account=state.use_account_settings)
+        handler._write_setting("QuickDock", "width", str(state.quick_dock_width), to_account=use_account_settings())
 
     PyImGui.spacing()
     new_height = draw_labeled_slider("Quick Dock Height:", "##rheight", state.quick_dock_height, 20, 150)
     if new_height != state.quick_dock_height:
         state.quick_dock_height = new_height
-        handler._write_setting("QuickDock", "height", str(state.quick_dock_height), to_account=state.use_account_settings)
+        handler._write_setting("QuickDock", "height", str(state.quick_dock_height), to_account=use_account_settings())
 
     PyImGui.spacing()
     new_bpr = draw_labeled_slider("Buttons Per Row:", "##bpr", state.buttons_per_row, 1, 16)
     if new_bpr != state.buttons_per_row:
         state.buttons_per_row = new_bpr
-        handler._write_setting("QuickDock", "buttons_per_row", str(state.buttons_per_row), to_account=state.use_account_settings)
+        handler._write_setting("QuickDock", "buttons_per_row", str(state.buttons_per_row), to_account=use_account_settings())
     
     PyImGui.spacing()
-    label = "Lock Quick Dock location" if state.quick_dock_unlocked else "Unlock Quick Dock location"
+    label = "Quick Dock is Unlocked" if state.quick_dock_unlocked else "Quick Dock is Locked"
     qd_unlocked = PyImGui.checkbox(label, state.quick_dock_unlocked)
     if qd_unlocked != state.quick_dock_unlocked:
         state.quick_dock_unlocked = qd_unlocked
-        handler._write_setting("QuickDock", "unlocked", str(qd_unlocked), to_account=state.use_account_settings)
-    ImGui.show_tooltip("You can also Unlock and Lock it by Middle-Clicking the Quick Dock")
+        handler._write_setting("QuickDock", "unlocked", str(qd_unlocked), to_account=use_account_settings())
+    ImGui.show_tooltip("Click to lock" if state.quick_dock_unlocked else "Click to unlock")
     
     PyImGui.spacing()
     label = "Reset Quick Dock Settings"
@@ -267,7 +269,7 @@ def draw_quick_dock_config():
         new_dock_enabled = PyImGui.checkbox(f"##dock_{idx}", bool(dock_enabled))
         if new_dock_enabled != dock_enabled:
             data["quickdock"] = new_dock_enabled
-            handler._write_setting(name, "quickdock", str(new_dock_enabled), to_account=state.use_account_settings)
+            handler._write_setting(name, "quickdock", str(new_dock_enabled), to_account=use_account_settings())
     PyImGui.end_child()
 
 def draw_debug_config():
@@ -300,7 +302,7 @@ def draw_debug_config():
         updated_enabled = PyImGui.checkbox("Enabled", enabled)
         if updated_enabled != enabled:
             info["enabled"] = updated_enabled
-            handler._write_setting(state.selected_widget, "enabled", str(updated_enabled), to_account=state.use_account_settings)
+            handler._write_setting(state.selected_widget, "enabled", str(updated_enabled), to_account=use_account_settings())
 
         PyImGui.spacing()
         label = "Widget Category:"
@@ -343,12 +345,12 @@ def draw_debug_config():
         
         if new_index != current_index:
             data["icon"] = icon_names[new_index]
-            handler._write_setting(state.selected_widget, "icon", icon_names[new_index], to_account=state.use_account_settings)
+            handler._write_setting(state.selected_widget, "icon", icon_names[new_index], to_account=use_account_settings())
 
         if new_category != category:
             data["category"] = new_category
-            handler._write_setting(state.selected_widget, "category", new_category, to_account=state.use_account_settings)
+            handler._write_setting(state.selected_widget, "category", new_category, to_account=use_account_settings())
 
         if new_sub != subcategory:
             data["subcategory"] = new_sub
-            handler._write_setting(state.selected_widget, "subcategory", new_sub, to_account=state.use_account_settings)
+            handler._write_setting(state.selected_widget, "subcategory", new_sub, to_account=use_account_settings())

--- a/Widgets/widget_manager/ui_embedded_config.py
+++ b/Widgets/widget_manager/ui_embedded_config.py
@@ -1,6 +1,7 @@
 from Py4GWCoreLib import *
 from . import state
 from .handler import handler
+from .config_scope import use_account_settings
 from .ui_config_sections import draw_account_widget_config, draw_quick_dock_config, draw_debug_config, draw_floating_menu_config
 
 def draw_embedded_widget_config():
@@ -105,7 +106,7 @@ def draw_embedded_widget_config():
                 new_old_menu = PyImGui.checkbox("Disable Old Floating Menu" if state.old_menu else "Enable Old Floating Menu", state.old_menu)
                 if new_old_menu != state.old_menu:
                     state.old_menu = new_old_menu
-                    handler._write_setting("WidgetManager", "old_menu", str(state.old_menu), to_account=state.use_account_settings)
+                    handler._write_setting("WidgetManager", "old_menu", str(state.old_menu), to_account=use_account_settings())
                 PyImGui.show_tooltip("Disable Old Floating Menu" if state.old_menu else "Enable Old Floating Menu")
                 
                 PyImGui.spacing()              

--- a/Widgets/widget_manager/ui_floating_menu.py
+++ b/Widgets/widget_manager/ui_floating_menu.py
@@ -178,14 +178,16 @@ def draw_floating_menu():
         else:
             button_label = f"{icon} Widgets##WigetUIButton"
         
+        state.hovering_floating_button = False
         if PyImGui.button(button_label, 0, 0):
-                state.hovering_floating_button = PyImGui.is_item_hovered()
-                PyImGui.open_popup("FloatingMenu")
-                state.popup_open = True
+            PyImGui.open_popup("FloatingMenu")
+            state.popup_open = True
+            
+        state.hovering_floating_button = PyImGui.is_item_hovered()
+            
         PyImGui.set_next_window_pos(menu_x, menu_y)
         PyImGui.pop_style_color(5)
         PyImGui.pop_style_var(2)
-        
         if PyImGui.begin_popup("FloatingMenu"):
             state.popup_height = PyImGui.get_window_height()
             state.popup_height_known = True

--- a/Widgets/widget_manager/ui_old_menu.py
+++ b/Widgets/widget_manager/ui_old_menu.py
@@ -1,5 +1,6 @@
 from Py4GWCoreLib import *
 from .handler import handler
+from .config_scope import use_account_settings
 from . import state
          
 def draw_old_widget_ui():
@@ -15,13 +16,13 @@ def draw_old_widget_ui():
         current_pos = PyImGui.get_window_pos()
         if current_pos != state.old_menu_window_pos:
             state.old_menu_window_pos = tuple(current_pos)
-            handler._write_setting("WidgetManager", "omx", str(int(current_pos[0])), to_account=state.use_account_settings)
-            handler._write_setting("WidgetManager", "omy", str(int(current_pos[1])), to_account=state.use_account_settings)
+            handler._write_setting("WidgetManager", "omx", str(int(current_pos[0])), to_account=use_account_settings())
+            handler._write_setting("WidgetManager", "omy", str(int(current_pos[1])), to_account=use_account_settings())
 
         collapsed = PyImGui.is_window_collapsed()
         if collapsed != state.old_menu_window_collapsed:
             state.old_menu_window_collapsed = collapsed
-            handler._write_setting("WidgetManager", "collapsed", str(collapsed), to_account=state.use_account_settings)
+            handler._write_setting("WidgetManager", "collapsed", str(collapsed), to_account=use_account_settings())
         if PyImGui.button(IconsFontAwesome5.ICON_RETWEET + "##Reload Widgets"):
             ConsoleLog(state.module_name, "Reloading Widgets...", Py4GW.Console.MessageType.Info)
             state.initialized = False
@@ -81,7 +82,7 @@ def draw_widget_contents_old():
                 new_enabled = PyImGui.checkbox(name, bool(info["enabled"]))
                 if new_enabled != info["enabled"]:
                     info["enabled"] = new_enabled
-                    handler._write_setting(name, "enabled", str(new_enabled), to_account=state.use_account_settings)
+                    handler._write_setting(name, "enabled", str(new_enabled), to_account=use_account_settings())
                     
                 PyImGui.table_set_column_index(1)
                 if info["enabled"]:

--- a/Widgets/widget_manager/ui_quickdock.py
+++ b/Widgets/widget_manager/ui_quickdock.py
@@ -8,9 +8,8 @@ def quick_dock_menu():
     left, top, right, bottom = UIManager.GetFrameCoords(fullscreen_frame_id)
 
     mouse_x, mouse_y = Overlay().GetMouseCoords()
-    edge_threshold = 30
-
-    if state.quick_dock_unlocked and PyImGui.is_mouse_dragging(0, -1.0):
+    if state.quick_dock_unlocked and PyImGui.is_mouse_dragging(0, -1.0) and state.quick_dock_hovering_button:
+        edge_threshold = 30
         if mouse_y < top + edge_threshold:
             state.quick_dock_edge[0] = "top"
             handler._write_setting("QuickDock", "edge", "top", to_account=use_account_settings())
@@ -55,6 +54,7 @@ def quick_dock_menu():
     if PyImGui.begin("##quick_dock_toggle", PyImGui.WindowFlags.NoTitleBar | PyImGui.WindowFlags.NoResize | PyImGui.WindowFlags.NoScrollbar | PyImGui.WindowFlags.NoBackground):
         PyImGui.push_style_var(ImGui.ImGuiStyleVar.FrameRounding, 0)
         PyImGui.push_style_var(ImGui.ImGuiStyleVar.WindowRounding, 0)
+        state.quick_dock_hovering_button = False
         if PyImGui.button("##toggle_ribbon", quick_dock_w, quick_dock_h):
             state.show_quick_dock_popup = not state.show_quick_dock_popup
         # PyImGui.show_tooltip("Middle Click to Lock" if state.quick_dock_unlocked else "Middle Click to Unlock")
@@ -62,7 +62,7 @@ def quick_dock_menu():
             ImGui.show_tooltip("Middle-click to Lock/Unlock")
             if PyImGui.is_mouse_clicked(2):
                 state.quick_dock_unlocked = not state.quick_dock_unlocked
-        
+        state.quick_dock_hovering_button = PyImGui.is_item_active()
         
         if state.quick_dock_unlocked and PyImGui.is_item_active():
             if state.quick_dock_edge[0] in ("left", "right"):

--- a/Widgets/widget_manager/ui_quickdock.py
+++ b/Widgets/widget_manager/ui_quickdock.py
@@ -1,6 +1,7 @@
 from Py4GWCoreLib import *
 from . import state
 from .handler import handler
+from .config_scope import use_account_settings
 
 def quick_dock_menu():
     fullscreen_frame_id = UIManager.GetFrameIDByHash(140452905)
@@ -12,16 +13,16 @@ def quick_dock_menu():
     if state.quick_dock_unlocked and PyImGui.is_mouse_dragging(0, -1.0):
         if mouse_y < top + edge_threshold:
             state.quick_dock_edge[0] = "top"
-            handler._write_setting("QuickDock", "edge", "top", to_account=state.use_account_settings)
+            handler._write_setting("QuickDock", "edge", "top", to_account=use_account_settings())
         elif mouse_y > bottom - edge_threshold:
             state.quick_dock_edge[0] = "bottom"
-            handler._write_setting("QuickDock", "edge", "bottom", to_account=state.use_account_settings)
+            handler._write_setting("QuickDock", "edge", "bottom", to_account=use_account_settings())
         elif mouse_x < left + edge_threshold:
             state.quick_dock_edge[0] = "left"
-            handler._write_setting("QuickDock", "edge", "left", to_account=state.use_account_settings)
+            handler._write_setting("QuickDock", "edge", "left", to_account=use_account_settings())
         elif mouse_x > right - edge_threshold:
             state.quick_dock_edge[0] = "right"
-            handler._write_setting("QuickDock", "edge", "right", to_account=state.use_account_settings)
+            handler._write_setting("QuickDock", "edge", "right", to_account=use_account_settings())
 
     if state.quick_dock_edge[0] == "left":
         quick_dock_x = left - 10
@@ -57,8 +58,10 @@ def quick_dock_menu():
         if PyImGui.button("##toggle_ribbon", quick_dock_w, quick_dock_h):
             state.show_quick_dock_popup = not state.show_quick_dock_popup
         # PyImGui.show_tooltip("Middle Click to Lock" if state.quick_dock_unlocked else "Middle Click to Unlock")
-        if PyImGui.is_item_hovered() and PyImGui.is_mouse_clicked(2):
-            state.quick_dock_unlocked = not state.quick_dock_unlocked
+        if PyImGui.is_item_hovered():
+            ImGui.show_tooltip("Middle-click to Lock/Unlock")
+            if PyImGui.is_mouse_clicked(2):
+                state.quick_dock_unlocked = not state.quick_dock_unlocked
         
         
         if state.quick_dock_unlocked and PyImGui.is_item_active():
@@ -128,7 +131,7 @@ def quick_dock_menu():
 
                 if PyImGui.button(label, *button_size):
                     widget["enabled"] = not enabled
-                    handler._write_setting(name, "enabled", str(widget["enabled"]), to_account=state.use_account_settings)
+                    handler._write_setting(name, "enabled", str(widget["enabled"]), to_account=use_account_settings())
 
                 if PyImGui.is_item_hovered():
                     PyImGui.begin_tooltip()

--- a/Widgets/widget_manager/ui_widget_menu.py
+++ b/Widgets/widget_manager/ui_widget_menu.py
@@ -1,5 +1,6 @@
 from Py4GWCoreLib import *
 from .handler import handler
+from .config_scope import use_account_settings
 from . import state
 
 def draw_widget_popup_menus():
@@ -29,7 +30,7 @@ def draw_widget_popup_menus():
                         new_enabled = PyImGui.checkbox(name, info["enabled"])
                         if new_enabled != info["enabled"]:
                             info["enabled"] = new_enabled
-                            handler._write_setting(name, "enabled", str(new_enabled), to_account=state.use_account_settings)
+                            handler._write_setting(name, "enabled", str(new_enabled), to_account=use_account_settings())
 
                         PyImGui.table_set_column_index(1)
                         if info["enabled"]:


### PR DESCRIPTION
### Summary
- Refactored `use_account_settings` and `selected_settings_scope` into a new `config_scope.py` to eliminate circular imports between `handler.py` and `state.py`.
- Updated `initialize_settings()` to read `use_account_settings` directly from the INI file and apply correct settings scope on launch.
- Normalized all relative imports within the `widget_manager` package.
- Improved floating button drag logic:
  - Dragging is now allowed only when the mouse is held directly on the floating button.
  - Prevents accidental dragging when interacting with other UI elements.
- Improved Quick Dock drag logic:
  - Dragging is now allowed only when the mouse is held directly on the quick dock ribbon.
  - Prevents accidental dragging when interacting with other UI elements.

- Clarified Quick Dock locking/unlocking UX (middle-click with helpful tool tip).
- Verified  correct widget loading, and no runtime (widget-manager just runs widgets they need to be safe).

### Why
- Prevent startup import crashes caused by cyclic references.
- Ensure floating elements behave predictably and only respond to intended mouse input.
- Improve maintainability and readability of the widget manager module.
- safe calls required from widgets as manager has no guard rails