### PR TITLE
fix(widgets): Adjusted loading screen checks to reduce potential crashes

### DIFF
--- a/Py4GWCoreLib/frame_aliases.json
+++ b/Py4GWCoreLib/frame_aliases.json
@@ -1135,5 +1135,14 @@
     "1431953425,1,4294967292": "Control Options Tab",
     "1431953425,1,3": "Control Options Tab Internal",
     "1431953425,1,2": "Sound Options Tab Internal",
-    "1431953425,0": "Options Window GW Version"
+    "1431953425,0": "Options Window GW Version",
+    "140452905,10": "did_not_cleaning_disconnect_popup_charselect",
+    "1398610279": "did_not_cleaning_disconnect_popup_charselect_YES_BUTTON",
+    "3600335809": "did_not_cleaning_disconnect_popup_charselect_NO_BUTTON",
+    "329735997": "did_not_cleaning_disconnect_popup_charselect_TEXT_FRAME",
+    "4026955783": "did_not_cleaning_disconnect_popup_charselect_QUESTION_MARK",
+    "140452905,17,0": "guild_wars_was_unable_to_complete_the_operation_popup_charselect",
+    "140452905,17,0,0": "guild_wars_was_unable_to_complete_the_operation_popup_charselect_EXCLIMATION_MARK",
+    "140452905,17,0,5": "guild_wars_was_unable_to_complete_the_operation_popup_charselect_OK_BUTTON",
+    "140452905,17,0,1": "guild_wars_was_unable_to_complete_the_operation_popup_charselect_TEXT_FRAME"
 }

--- a/Widgets/Action Queue Monitor.py
+++ b/Widgets/Action Queue Monitor.py
@@ -18,7 +18,9 @@ def main():
             "IDENTIFY",  
         }
     
-    flags = PyImGui.WindowFlags.AlwaysAutoResize
+    if not Routines.Checks.Map.MapValid():
+        return
+    
     if PyImGui.begin("ActionQueue Monitor", PyImGui.WindowFlags.AlwaysAutoResize):
         if PyImGui.begin_tab_bar("InfoTabBar"):
             for queue_name in all_queues:

--- a/Widgets/Dialog Sync.py
+++ b/Widgets/Dialog Sync.py
@@ -159,7 +159,7 @@ def main():
     global last_model, last_choice, last_choice_time, state, last_leader_pos
     global win_x, win_y, win_collapsed, first_run_window
 
-    if Routines.Checks.Map.MapValid() and Map.IsOutpost():
+    if not Routines.Checks.Map.MapValid() or Map.IsOutpost():
         return
 
     # —— 0) Move-to-leader FSM ——

--- a/Widgets/Switch Character.py
+++ b/Widgets/Switch Character.py
@@ -281,6 +281,12 @@ def configure():
 def main():
     global reroll_widget, window_module
     try:
+        
+        sort_cs_frame = UIManager.IsWindowVisible(UIManager.GetChildFrameID(2232987037,[0]))
+        
+        if sort_cs_frame and not Routines.Checks.Map.MapValid():
+            return
+        
         reroll_widget.Update()
         DrawWindow()
     except Exception as e:


### PR DESCRIPTION
Improved validation logic in several widgets to prevent execution during invalid map states or while transitioning through load screens. This helps avoid critical crashes, especially in routines triggered mid-transition.

Added more frames to frame_aliases

Updated:
- Action Queue Monitor
- Dialog Sync
- Switch Character
- frame_aliases.json

Ensures more robust handling of map-dependent logic and safer widget behavior during state transitions.