### PR TITLE
fix+refactor(widget_manager): patch metadata and remove wildcards

### DIFF
--- a/Widgets/widget_manager/config_scope.py
+++ b/Widgets/widget_manager/config_scope.py
@@ -1,4 +1,4 @@
-from Py4GWCoreLib import *
+from Py4GWCoreLib import UIManager
 # config_scope.py
 selected_settings_scope = 0  # 0 = Global, 1 = Account
 

--- a/Widgets/widget_manager/main.py
+++ b/Widgets/widget_manager/main.py
@@ -1,4 +1,4 @@
-from Py4GWCoreLib import *
+from Py4GWCoreLib import Py4GW, Map, Party
 import traceback
 import sys
 

--- a/Widgets/widget_manager/settings_io.py
+++ b/Widgets/widget_manager/settings_io.py
@@ -1,18 +1,6 @@
-from Py4GWCoreLib import *
 from .handler import handler
 from .config_scope import use_account_settings
 from . import state
-
-def write_settings_to_ini():
-    if not state.write_timer.HasElapsed(1000):
-        return
-
-    # if state.use_account_settings:
-    #     # save_account_settings()
-    # else:
-    #     # save_global_settings()
-    
-    state.write_timer.Reset()
 
 def restore_global_defaults():
     from .default_settings import global_widget_defaults
@@ -91,6 +79,9 @@ def initialize_settings():
 
 def load_account_settings():
     from . import config_scope
+    
+    handler._initialize_account_settings()
+    
     state.enable_all = handler._read_setting_bool("WidgetManager", "enable_all", False, force_account=True)
     state.old_menu = handler._read_setting_bool("WidgetManager", "old_menu", True, force_account=True)
     config_scope.selected_settings_scope = 1 if handler._read_setting_bool("WidgetManager", "use_account_settings", True, force_account=True) else 0

--- a/Widgets/widget_manager/state.py
+++ b/Widgets/widget_manager/state.py
@@ -1,4 +1,4 @@
-from Py4GWCoreLib import *
+from Py4GWCoreLib import ImGui, PyImGui
 from .handler import handler
 
 module_name = "WidgetManager"
@@ -90,11 +90,4 @@ window_module.window_pos = (window_x, window_y)
 window_module.collapse = handler._read_setting_bool(module_name, "collapsed", True)
 old_menu_window_collapsed = window_module.collapse
 old_menu_window_pos = window_module.window_pos
-
-# Write throttle
-write_timer = Timer()
-write_timer.Start()
-
-menu_write_timer = Timer()
-write_timer.Start()
     

--- a/Widgets/widget_manager/ui_config_sections.py
+++ b/Widgets/widget_manager/ui_config_sections.py
@@ -1,4 +1,4 @@
-from Py4GWCoreLib import *
+from Py4GWCoreLib import PyImGui, ImGui, IconsFontAwesome5
 from . import state
 from .handler import handler
 from .config_scope import use_account_settings, is_in_character_select

--- a/Widgets/widget_manager/ui_embedded_config.py
+++ b/Widgets/widget_manager/ui_embedded_config.py
@@ -1,4 +1,4 @@
-from Py4GWCoreLib import *
+from Py4GWCoreLib import UIManager, EnumPreference, PyImGui, ImGui, Utils
 from . import state
 from .handler import handler
 from .config_scope import use_account_settings

--- a/Widgets/widget_manager/ui_floating_menu.py
+++ b/Widgets/widget_manager/ui_floating_menu.py
@@ -1,4 +1,4 @@
-from Py4GWCoreLib import *
+from Py4GWCoreLib import PyImGui, ImGui, UIManager, Map, Overlay, IconsFontAwesome5, Py4GW, ConsoleLog
 from . import state
 from .handler import handler
 from .ui_widget_menu import draw_widget_popup_menus

--- a/Widgets/widget_manager/ui_old_menu.py
+++ b/Widgets/widget_manager/ui_old_menu.py
@@ -1,4 +1,4 @@
-from Py4GWCoreLib import *
+from Py4GWCoreLib import PyImGui, ImGui, IconsFontAwesome5, ConsoleLog, Py4GW, Utils
 from .handler import handler
 from .config_scope import use_account_settings
 from . import state

--- a/Widgets/widget_manager/ui_quickdock.py
+++ b/Widgets/widget_manager/ui_quickdock.py
@@ -1,4 +1,4 @@
-from Py4GWCoreLib import *
+from Py4GWCoreLib import UIManager, Overlay, PyImGui, ImGui, IconsFontAwesome5
 from . import state
 from .handler import handler
 from .config_scope import use_account_settings

--- a/Widgets/widget_manager/ui_widget_menu.py
+++ b/Widgets/widget_manager/ui_widget_menu.py
@@ -1,4 +1,4 @@
-from Py4GWCoreLib import *
+from Py4GWCoreLib import PyImGui, ImGui, Utils, ConsoleLog, IconsFontAwesome5, Py4GW
 from .handler import handler
 from .config_scope import use_account_settings
 from . import state


### PR DESCRIPTION
Fixes fallback widget metadata by updating category/subcategory fields using defaults when placeholders are detected. Skips non-widget sections like WidgetManager and QuickDock to avoid incorrect updates.

Refactors all `import *` statements across widget manager modules to explicit imports to improve clarity, avoid namespace pollution.

Also handles reinitialization of missing account folders or INI files if deleted during runtime.