### PR TITLE
Update "mistrust" custom_skill.py

### DIFF
--- a/HeroAI/custom_skill.py
+++ b/HeroAI/custom_skill.py
@@ -4662,8 +4662,9 @@ class CustomSkillClass:
         skill = self.CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Mistrust")
         skill.SkillType = SkillType.Hex.value
-        skill.TargetAllegiance = Skilltarget.EnemyCaster.value
-        skill.Nature = SkillNature.Offensive.value
+        skill.TargetAllegiance = Skilltarget.EnemyCastingSpell.value
+        skill.Nature = SkillNature.Interrupt.value
+        skill.Conditions.IsCasting = True
         self.skill_data[skill.SkillID] = skill
 
         skill = self.CustomSkill()


### PR DESCRIPTION
I tested with this new behavior and it performs better on enemy casters. The idea is to cast mistrust as soon as the enemy is using an enemy spell in order to "block" him. The skill nature interrupt will prioritise the usage. Also, I noticed that in previous version it wrongly used it on meeles