### PR TITLE
[YAVB] Added simple improvements to make Mesmers and Assassins more effective

### DIFF
--- a/Py4GWCoreLib/routines_src/Yield.py
+++ b/Py4GWCoreLib/routines_src/Yield.py
@@ -216,6 +216,17 @@ class Yield:
             if log:
                 ConsoleLog("CastSkillID", f"Cast {GLOBAL_CACHE.Skill.GetName(skill_id)}, slot: {GLOBAL_CACHE.SkillBar.GetSlotBySkillID(skill_id)}", Console.MessageType.Info)
             return True
+        
+        @staticmethod
+        def IsSkillIdUsable(skill_id: int):
+            from .Checks import Checks
+
+            if not GLOBAL_CACHE.Map.IsMapReady():
+                return False
+            player_agent_id = GLOBAL_CACHE.Player.GetAgentID()
+            enough_energy = Checks.Skills.HasEnoughEnergy(player_agent_id,skill_id)
+            skill_ready = Checks.Skills.IsSkillIDReady(skill_id)
+            return enough_energy and skill_ready
 
         @staticmethod
         def CastSkillSlot(slot:int,extra_condition=True, aftercast_delay=0, log=False):

--- a/YAVB/BuildMgr.py
+++ b/YAVB/BuildMgr.py
@@ -118,10 +118,8 @@ class ShadowFormAssassinVaettir(Build):
         
     def DefensiveActions(self):
         player_agent_id = GLOBAL_CACHE.Player.GetAgentID()
-        has_shadow_form = Routines.Checks.Effects.HasBuff(player_agent_id,self.shadow_form)
-        shadow_form_buff_time_remaining = GLOBAL_CACHE.Effects.GetEffectTimeRemaining(player_agent_id,self.shadow_form) if has_shadow_form else 0
         has_deadly_paradox = Routines.Checks.Effects.HasBuff(player_agent_id, self.deadly_paradox)
-        if shadow_form_buff_time_remaining <= 3500:
+        if Routines.Yield.Skills.IsSkillIdUsable(self.shadow_form):
             if Routines.Yield.Skills.CastSkillID(self.deadly_paradox,extra_condition=(not has_deadly_paradox), log=False, aftercast_delay=100):
                 ConsoleLog(self.build_name, "Casting Deadly Paradox.", Py4GW.Console.MessageType.Info, log=False)
                 yield from Routines.Yield.wait(100)
@@ -219,16 +217,11 @@ class ShadowFormAssassinVaettir(Build):
                 return
 
             player_agent_id = GLOBAL_CACHE.Player.GetAgentID()
+            has_shadow_form = Routines.Checks.Effects.HasBuff(player_agent_id,self.shadow_form)
+            shadow_form_buff_time_remaining = GLOBAL_CACHE.Effects.GetEffectTimeRemaining(player_agent_id,self.shadow_form) if has_shadow_form else 0
             if Routines.Checks.Agents.InDanger(Range.Spellcast):
-                has_shadow_form = Routines.Checks.Effects.HasBuff(player_agent_id,self.shadow_form)
-                shadow_form_buff_time_remaining = GLOBAL_CACHE.Effects.GetEffectTimeRemaining(player_agent_id,self.shadow_form) if has_shadow_form else 0
                 has_deadly_paradox = Routines.Checks.Effects.HasBuff(player_agent_id, self.deadly_paradox)
-                if self.in_killing_routine:
-                    time_remaining = 4000
-                else:
-                    time_remaining = 3500
-                    
-                if shadow_form_buff_time_remaining <= time_remaining:
+                if Routines.Yield.Skills.IsSkillIdUsable(self.shadow_form):
                     GLOBAL_CACHE._ActionQueueManager.ResetQueue("ACTION")
                     if Routines.Yield.Skills.CastSkillID(self.deadly_paradox,extra_condition=(not has_deadly_paradox), log=False, aftercast_delay=200):
                         ConsoleLog(self.build_name, "Casting Deadly Paradox.", Py4GW.Console.MessageType.Info, log=False)
@@ -300,10 +293,10 @@ class ShadowFormAssassinVaettir(Build):
                         yield from Routines.Yield.wait(350)
                         continue
                         
-            if self.in_killing_routine:
+            if self.in_killing_routine and has_shadow_form and has_shroud_of_distress and has_channeling:
                 both_ready = Routines.Checks.Skills.IsSkillSlotReady(self.wastrels_demise_slot) and Routines.Checks.Skills.IsSkillSlotReady(self.arcane_echo_slot)
                 target = GetNotHexedEnemy()
-                if target:
+                if target and shadow_form_buff_time_remaining >= 4000:
                     GLOBAL_CACHE._ActionQueueManager.ResetQueue("ACTION")
                     GLOBAL_CACHE.Player.ChangeTarget(target)
                     if Routines.Yield.Skills.CastSkillSlot(self.arcane_echo_slot, extra_condition=both_ready, log=False, aftercast_delay=2850):
@@ -317,7 +310,7 @@ class ShadowFormAssassinVaettir(Build):
                             yield from Routines.Yield.wait(1000)
                 
                 target = GetNotHexedEnemy()  
-                if target: 
+                if target and not Routines.Checks.Skills.IsSkillSlotReady(self.arcane_echo_slot): 
                     GLOBAL_CACHE._ActionQueueManager.ResetQueue("ACTION")
                     GLOBAL_CACHE.Player.ChangeTarget(target)
                     if Routines.Yield.Skills.CastSkillSlot(self.wastrels_demise_slot, log=False, aftercast_delay=1000):
@@ -382,10 +375,8 @@ class ShadowFormMesmerVaettir(Build):
         
     def DefensiveActions(self):
         player_agent_id = GLOBAL_CACHE.Player.GetAgentID()
-        has_shadow_form = Routines.Checks.Effects.HasBuff(player_agent_id,self.shadow_form)
-        shadow_form_buff_time_remaining = GLOBAL_CACHE.Effects.GetEffectTimeRemaining(player_agent_id,self.shadow_form) if has_shadow_form else 0
         has_deadly_paradox = Routines.Checks.Effects.HasBuff(player_agent_id, self.deadly_paradox)
-        if shadow_form_buff_time_remaining <= 3500:
+        if Routines.Yield.Skills.IsSkillIdUsable(self.shadow_form):
             if Routines.Yield.Skills.CastSkillID(self.deadly_paradox,extra_condition=(not has_deadly_paradox), log=False, aftercast_delay=100):
                 ConsoleLog(self.build_name, "Casting Deadly Paradox.", Py4GW.Console.MessageType.Info, log=False)
                 yield from Routines.Yield.wait(100)
@@ -483,16 +474,12 @@ class ShadowFormMesmerVaettir(Build):
                 return
 
             player_agent_id = GLOBAL_CACHE.Player.GetAgentID()
+            has_shadow_form = Routines.Checks.Effects.HasBuff(player_agent_id,self.shadow_form)
+            shadow_form_buff_time_remaining = GLOBAL_CACHE.Effects.GetEffectTimeRemaining(player_agent_id,self.shadow_form) if has_shadow_form else 0
             if Routines.Checks.Agents.InDanger(Range.Spellcast):
-                has_shadow_form = Routines.Checks.Effects.HasBuff(player_agent_id,self.shadow_form)
-                shadow_form_buff_time_remaining = GLOBAL_CACHE.Effects.GetEffectTimeRemaining(player_agent_id,self.shadow_form) if has_shadow_form else 0
                 has_deadly_paradox = Routines.Checks.Effects.HasBuff(player_agent_id, self.deadly_paradox)
-                if self.in_killing_routine:
-                    time_remaining = 4000
-                else:
-                    time_remaining = 3500
                     
-                if shadow_form_buff_time_remaining <= time_remaining:
+                if Routines.Yield.Skills.IsSkillIdUsable(self.shadow_form):
                     GLOBAL_CACHE._ActionQueueManager.ResetQueue("ACTION")
                     if Routines.Yield.Skills.CastSkillID(self.deadly_paradox,extra_condition=(not has_deadly_paradox), log=False, aftercast_delay=200):
                         ConsoleLog(self.build_name, "Casting Deadly Paradox.", Py4GW.Console.MessageType.Info, log=False)
@@ -503,8 +490,9 @@ class ShadowFormMesmerVaettir(Build):
                         yield from Routines.Yield.wait(1950)
                         continue
 
+            
             has_shroud_of_distress = Routines.Checks.Effects.HasBuff(player_agent_id,self.shroud_of_distress)
-            if not has_shroud_of_distress:
+            if not has_shroud_of_distress or (shadow_form_buff_time_remaining > 8000 and Routines.Yield.Skills.IsSkillIdUsable(self.shroud_of_distress)):
                 ConsoleLog(self.build_name, "Casting Shroud of Distress.", Py4GW.Console.MessageType.Info, log=False)
                 # ** Cast Shroud of Distress **
                 GLOBAL_CACHE._ActionQueueManager.ResetQueue("ACTION")
@@ -561,11 +549,11 @@ class ShadowFormMesmerVaettir(Build):
                     if Routines.Yield.Skills.CastSkillID(self.heart_of_shadow, log=False, aftercast_delay=350):
                         yield from Routines.Yield.wait(350)
                         continue
-                        
-            if self.in_killing_routine:
+
+            if self.in_killing_routine and has_shadow_form and has_shroud_of_distress and has_mantra_of_earth:
                 both_ready = Routines.Checks.Skills.IsSkillSlotReady(self.wastrels_demise_slot) and Routines.Checks.Skills.IsSkillSlotReady(self.arcane_echo_slot)
                 target = GetNotHexedEnemy()
-                if target:
+                if target and shadow_form_buff_time_remaining >= 4000:
                     GLOBAL_CACHE._ActionQueueManager.ResetQueue("ACTION")
                     GLOBAL_CACHE.Player.ChangeTarget(target)
                     if Routines.Yield.Skills.CastSkillSlot(self.arcane_echo_slot, extra_condition=both_ready, log=False, aftercast_delay=2050):
@@ -579,7 +567,7 @@ class ShadowFormMesmerVaettir(Build):
                             yield from Routines.Yield.wait(1000)
                 
                 target = GetNotHexedEnemy()  
-                if target: 
+                if target and not Routines.Checks.Skills.IsSkillSlotReady(self.arcane_echo_slot): 
                     GLOBAL_CACHE._ActionQueueManager.ResetQueue("ACTION")
                     GLOBAL_CACHE.Player.ChangeTarget(target)
                     if Routines.Yield.Skills.CastSkillSlot(self.wastrels_demise_slot, log=False, aftercast_delay=1000):


### PR DESCRIPTION
* Changed how SF is casted to be casted as soon as it's available
* For mesmers, we are stacking enchantments making it more defensive as its moving around
* Added checks during kill routine to not cast skills if there's a risk of SF not being casted on time
* Added checks during kill routine to not spam attack skills without proper energy management and defensive utility casted first
* Added `IsSkillIdUsable` so we can check if a skill can be casted, specifically SF.
* Added Shroud for mesmers the ability to stack it consistently and avoid running out of it and get spanked to death.

Results for mesmers is 253 runs 1 death
Results for Assassins is 100 runs 1 death