### PR TITLE
Updates BlessingNpc enum

### DIFF
--- a/Bots/aC_Scripts/aC_api/Blessing_Core.py
+++ b/Bots/aC_Scripts/aC_api/Blessing_Core.py
@@ -32,14 +32,14 @@ class BlessingNpc(Enum):
     Sunspear_Scout      = (4778, 4776)
     Wandering_Priest    = (5384, 5383)
     Vabbian_Scout       = (5632,)
-    Ghostly_Scout       = (5547,)
+    Ghostly_Scout       = (5547, 5548)
     Ghostly_Priest      = (5615,)
     Whispers_Informants = (5218, 5683)
     Kurzick_Priest      = (593, 912, 3426)
     Luxon_Priest        = (1947, 3641)
     Beacons_of_Droknar  = (5865,)
     Ascalonian_Refugees = (1986, 1987, 6044, 6045)
-    Asuran_Krewe        = (6755, 6756, 6775)
+    Asuran_Krewe        = (6755, 6756, 6775, 6779)
     Norn_Hunters        = (6374, 6380)
 
     def __init__(self, *mids: int):


### PR DESCRIPTION
Adds missing IDs to the BlessingNpc enum for
Ghostly_Scout and Asuran_Krewe.