### PR TITLE
Fix mega zoom overlay scaling alignment

### DIFF
--- a/Widgets/Mission Map +.py
+++ b/Widgets/Mission Map +.py
@@ -802,6 +802,7 @@ class MissionMap:
         self.renderer.world_space.set_zoom(zoom/100.0)
         self.mega_zoom_renderer.world_space.set_zoom(zoom/100.0)
         self.renderer.world_space.set_scale(self.scale_x)
+        self.mega_zoom_renderer.world_space.set_scale(self.scale_x)
         
         
         


### PR DESCRIPTION
## Summary
- ensure the mega zoom renderer updates its world space scale alongside the standard renderer so both overlays follow the interface size

## Issue
Mega zoom uses a second DXOverlay (self.mega_zoom_renderer) to draw the terrain/pathing layer, but MissionMap.update() only applies the current interface/UI scale (self.scale_x) to the primary renderer. The mega-zoom overlay is left at its default scale (1.0), so when the Guild Wars interface size is set to Small/Large/Larger the background geometry and marker math diverge, making NPC/enemy markers appear shifted during mega zoom.