### PR TITLE
Nightfall Leveler - Identity Theft quest fixes

### DIFF
--- a/Bots/Leveling/Nightfall/Nightfall_leveler.py
+++ b/Bots/Leveling/Nightfall/Nightfall_leveler.py
@@ -28,12 +28,12 @@ def create_bot_routine(bot: Botting) -> None:
     ExtendInventorySpace(bot)                  # Buy bags to extend inventory
     CompleteHeroCommandQuest(bot)              # Hero command quest
     CompleteArmoredTransportQuest(bot)         # Armored transport quest
-    CompleteIdentityTheftQuest(bot)           # Identity theft quest (not working yet)
     TakeInitialQuests(bot)                     # Take initial quest set
     FarmQuestRequirements(bot)                 # Farm materials/items for quests
     CompleteSunspearGreatHallQuests(bot)       # SSGH (Sunspear Great Hall) quests
     CompleteMissingShipmentQuest(bot)          # Level 5+ Missing Shipment quest
     ContinueQuestProgression(bot)              # Continue with quest chain
+    CompleteIdentityTheftQuest(bot)           # Identity theft quest (not working yet)
     
     # === PHASE 3: PROFESSION AND CHARACTER DEVELOPMENT ===
     UnlockSecondProfession(bot)                # Unlock second profession


### PR DESCRIPTION
The bot gets stuck at step 190, as the bot tries to travel to Champions Dawn which is not unlocked at this point. 

My suggestion is to move the Identity Theft part after ContinueQuestProgression, as in this step the outpost gets unlocked and the quest can be completed.
There was also a bug where the quest item didnt get collected before traveling back to Kamadan, due to being still infight. I fixed that as well.