### PR TITLE
Steam client fix

### DIFF
--- a/Py4GWCoreLib/GlobalCache/PlayerCache.py
+++ b/Py4GWCoreLib/GlobalCache/PlayerCache.py
@@ -14,6 +14,14 @@ class PlayerCache:
         self._name = ""
         self._action_queue_manager:ActionQueueManager = action_queue_manager
         self.login_characters = []
+
+    def _format_uuid_as_email(self, player_uuid):
+        if not player_uuid:
+            return ""
+        try:
+            return "uuid_" + "_".join(str(part) for part in player_uuid)
+        except TypeError:
+            return str(player_uuid)
         
     def _update_cache(self):
         self._player_instance.GetContext()
@@ -115,7 +123,10 @@ class PlayerCache:
         return self._player_instance.account_name
     
     def GetAccountEmail(self):
-        return self._player_instance.account_email
+        account_email = self._player_instance.account_email
+        if account_email:
+            return account_email
+        return self._format_uuid_as_email(self._player_instance.player_uuid)
     
     def GetPlayerUUID(self):
         return self._player_instance.player_uuid

--- a/Py4GWCoreLib/GlobalCache/SharedMemory.py
+++ b/Py4GWCoreLib/GlobalCache/SharedMemory.py
@@ -607,6 +607,20 @@ class Py4GWSharedMemoryManager:
     def _c_wchar_array_to_str(self,arr: ctypes.Array) -> str:
         """Convert c_wchar array back to Python str, stopping at null terminator."""
         return "".join(ch for ch in arr if ch != '\0').rstrip()
+
+    def _get_account_email(self) -> str:
+        if self.player_instance is None:
+            return ""
+        account_email = self.player_instance.account_email
+        if account_email:
+            return account_email
+        player_uuid = self.player_instance.player_uuid
+        if not player_uuid:
+            return ""
+        try:
+            return "uuid_" + "_".join(str(part) for part in player_uuid)
+        except TypeError:
+            return str(player_uuid)
     
     def _pack_extra_data_for_sendmessage(self, extra_tuple, maxlen=128):
         out = []
@@ -1464,7 +1478,7 @@ class Py4GWSharedMemoryManager:
             if self.map_instance.is_in_cinematic:
                 return
             
-            hero.AccountEmail = self.player_instance.account_email
+            hero.AccountEmail = self._get_account_email()
             agent_id = hero_data.agent_id
             map_region = self.map_instance.region_type.ToInt()
             
@@ -1663,7 +1677,7 @@ class Py4GWSharedMemoryManager:
             map_region = self.map_instance.region_type.ToInt()
             playerx, playery, playerz = agent_instance.x, agent_instance.y, agent_instance.z
             
-            pet.AccountEmail = self.player_instance.account_email
+            pet.AccountEmail = self._get_account_email()
             pet.AccountName = self.player_instance.account_name
             pet.CharacterName = f"Agent {pet_info.owner_agent_id} Pet"
             pet.IsHero = False

--- a/Py4GWCoreLib/Player.py
+++ b/Py4GWCoreLib/Player.py
@@ -8,6 +8,15 @@ from .Agent import *
 # Player
 class Player:
     @staticmethod
+    def _format_uuid_as_email(player_uuid):
+        if not player_uuid:
+            return ""
+        try:
+            return "uuid_" + "_".join(str(part) for part in player_uuid)
+        except TypeError:
+            return str(player_uuid)
+
+    @staticmethod
     def player_instance():
         """
         Helper method to create and return a PyPlayer instance.
@@ -286,7 +295,11 @@ class Player:
         Args: None
         Returns: str
         """
-        return Player.player_instance().account_email
+        player_instance = Player.player_instance()
+        account_email = player_instance.account_email
+        if account_email:
+            return account_email
+        return Player._format_uuid_as_email(player_instance.player_uuid)
     
     @staticmethod
     def GetPlayerUUID():


### PR DESCRIPTION
Adds a stable fallback for account identification when account_email is blank by deriving it from player_uuid.

- Player.py: GetAccountEmail() now returns the real email if present, otherwise formats player_uuid into uuid_<a>_<b>_<c>_<d>.
- PlayerCache.py: mirrors the same fallback logic so cached access to account email is consistent.
- SharedMemory.py: introduces _get_account_email() and uses it when writing hero/pet shared-memory records, ensuring those entries also get the UUID-based fallback.