### PR TITLE
Improve email retrieval with UUID check

### DIFF
--- a/Py4GWCoreLib/GlobalCache/PlayerCache.py
+++ b/Py4GWCoreLib/GlobalCache/PlayerCache.py
@@ -126,7 +126,7 @@ class PlayerCache:
         account_email = self._player_instance.account_email
         if account_email:
             return account_email
-        return self._format_uuid_as_email(self._player_instance.player_uuid)
+        return "" if all(part == 0 for part in self._player_instance.player_uuid) else self._format_uuid_as_email(self._player_instance.player_uuid)
     
     def GetPlayerUUID(self):
         return self._player_instance.player_uuid


### PR DESCRIPTION
This fixes some issues introduced with the uuid formatting as it was to simple.

The issue was GetAccountEmail would return "uuid_0_0_0_0" until the email is available, which is breaking all kind of logic. If the uuid is empty (0,0,0,0) it should return an empty string to indicate there is no value available. Only if the uuid is not empty and the email isn't available it should create that uuid string.