### PR TITLE
fix: MissionMap.MapProjection.WorldMapToScreen incorrectly inverted

### DIFF
--- a/Widgets/CustomBehaviors/primitives/auto_mover/auto_mover.py
+++ b/Widgets/CustomBehaviors/primitives/auto_mover/auto_mover.py
@@ -133,7 +133,7 @@ class AutoMover:
         ov = Overlay()
 
         # Mission Map window rect & clip (cast to int for API)
-        l, t, r, b = Map.MissionMap.GetMissionMapWindowCoords()
+        l, t, r, b = Map.MissionMap.GetWindowCoords()
         left, top, right, bottom = int(l), int(t), int(r), int(b)
         width, height = right - left, bottom - top
 


### PR DESCRIPTION
- removes an erroneous Y axis inversion in MissionMap.MapProjection.WorldMapToScreen which is not present in the equivalent MiniMap function

testing:
- both DEMO 2.0 and CB mission map overlays are rendered correctly for player pos and click-based pos