### PR TITLE
fix zoom jitter on Disable Camera Smoothing

### DIFF
--- a/Widgets/Disable Camera Smoothing.py
+++ b/Widgets/Disable Camera Smoothing.py
@@ -3,9 +3,8 @@ from Py4GWCoreLib import *
 MODULE_NAME = "Disable Camera Smoothing"
 
 def main():
-    computed = Camera.ComputeCameraPos()
-    current = Camera.GetPosition()
-    Camera.SetCameraPosition(computed.x, computed.y, current[2])
+    pos = Camera.GetCameraPositionToGo()
+    Camera.SetCameraPosition(pos[0], pos[1], pos[2])
 
 def configure():
     pass


### PR DESCRIPTION
using a different method here which doesnt freak out when you clip the camera into a wall