### PR TITLE
feat(player): add raw dialog and skill purchase method

### DIFF
--- a/Py4GWCoreLib/Player.py
+++ b/Py4GWCoreLib/Player.py
@@ -596,7 +596,16 @@ class Player:
         """
         ActionQueueManager().AddAction("ACTION",
         PlayerMethods.SetActiveTitle,title_id)
-        
+    
+    @staticmethod
+    def SendRawDialog(dialog_id: int):
+        """Send dialog using kSendAgentDialog. Works for NPC dialogs, skill trainers, etc."""
+        PlayerMethods.SendRawDialog(dialog_id)
+
+    @staticmethod
+    def BuySkill(skill_id: int):
+        """Buy/Learn a skill from a Skill Trainer."""
+        PlayerMethods.SendSkillTrainerDialog(skill_id)
         
     
     #region Not Worked

--- a/Py4GWCoreLib/native_src/methods/PlayerMethods.py
+++ b/Py4GWCoreLib/native_src/methods/PlayerMethods.py
@@ -1,6 +1,7 @@
 from ...Scanner import ScannerSection
 from ..internals.prototypes import Prototypes
 from ..internals.native_function import NativeFunction
+from ...py4gwcorelib_src.Utils import Utils
 
 from ...enums_src.UI_enums import UIMessage
 from ...Scanner import Scanner
@@ -382,3 +383,27 @@ class PlayerMethods:
 
         Game.enqueue(_do_action)
 
+    @staticmethod
+    def SendRawDialog(dialog_id: int) -> None:
+        """
+        Send a dialog using kSendAgentDialog.
+        Works for skill trainers, NPC dialogs, and merchant tabs.
+        """
+
+        def _action():
+            from ...UIManager import UIManager
+
+            UIManager.SendUIMessageRaw(UIMessage.kSendAgentDialog, dialog_id, 0)
+
+        Game.enqueue(_action)
+
+    @staticmethod
+    def SendSkillTrainerDialog(skill_id: int) -> None:
+        """
+        Buy/Learn a skill from a Skill Trainer.
+
+        Args:
+            skill_id: The skill ID to purchase
+        """
+        dialog_skill_id = Utils.SkillIdToDialogId(skill_id)
+        PlayerMethods.SendRawDialog(dialog_skill_id)

--- a/Py4GWCoreLib/py4gwcorelib_src/Utils.py
+++ b/Py4GWCoreLib/py4gwcorelib_src/Utils.py
@@ -752,5 +752,26 @@ class Utils:
         """Calculate the number of health pips based on max health and regeneration rate."""
         pips = (max_health * health_regen) / 2
         return int(pips)
+    
+    @staticmethod
+    def SkillIdToDialogId(skill_id: int) -> int:
+        """
+        Convert a skill ID to the dialog ID used by Skill Trainers.
+
+        This ORs the skill ID with the skill dialog mask (0x0A000000) to create
+        the dialog ID that can be sent via Player.SendDialog() to learn a skill.
+
+        Args:
+            skill_id (int): The skill ID to convert.
+
+        Returns:
+            int: The dialog ID for the Skill Trainer (skill_id | 0x0A000000).
+
+        Example:
+            dialog_id = Utils.SkillIdToDialogId(42)  # Returns 0x0A00002A
+            Player.SendDialog(dialog_id)
+        """
+        SKILL_DIALOG_MASK = 0x0A000000
+        return skill_id | SKILL_DIALOG_MASK
 
 #endregion

--- a/Widgets/Automation/Helpers/Dialogs/Skill Trainer.py
+++ b/Widgets/Automation/Helpers/Dialogs/Skill Trainer.py
@@ -1,0 +1,32 @@
+from Py4GWCoreLib import *
+
+MODULE_NAME = "Skill Learner"
+
+skill_id_input = 0
+status_message = ""
+
+
+def main():
+    global skill_id_input, status_message
+
+    if PyImGui.begin(MODULE_NAME):
+        PyImGui.text("Enter the Skill ID to learn:")
+        skill_id_input = PyImGui.input_int("Skill ID", skill_id_input)
+
+        PyImGui.separator()
+
+        if PyImGui.button("Learn Skill"):
+            if skill_id_input > 0:
+                Player.BuySkill(skill_id_input)
+                status_message = f"Sent request to learn skill {skill_id_input}"
+            else:
+                status_message = "Please enter a valid Skill ID"
+
+        if status_message:
+            PyImGui.text(status_message)
+
+    PyImGui.end()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add new methods to support sending raw dialogs and purchasing skills from skill trainers.
- Player.BuySkill(skill_id): buys or learns a skill from a skill trainer by invoking SendSkillTrainerDialog.
- Implement SendRawDialog and SendSkillTrainerDialog in PlayerMethods with UI message handling.
- Add utility method Utils.SkillIdToDialogId to convert skill IDs to dialog IDs for skill trainer interactions.
- Add a widget to train new skills from skill trainers NPCs.