### PR TITLE
Fix _run_bt_tree to always yield at least once on SUCCESS/FAILURE

### DIFF
--- a/Py4GWCoreLib/routines_src/Yield.py
+++ b/Py4GWCoreLib/routines_src/Yield.py
@@ -30,20 +30,18 @@ Routines = _RProxy()
 def _run_bt_tree(tree, return_bool: bool=False, throttle_ms: int = 100):
     """
     Drives a BT tree until SUCCESS / FAILURE, yielding periodically.
+    Always yields at least once to guarantee cooperative scheduling.
     If return_bool is True -> returns True/False.
     If return_bool is False -> just exits.
     """
     while True:
         state = tree.tick()
 
-        if state == BT.NodeState.SUCCESS:
+        if state in (BT.NodeState.SUCCESS, BT.NodeState.FAILURE):
+            yield
             if return_bool:
-                return True
-            break
-        elif state == BT.NodeState.FAILURE:
-            if return_bool:
-                return False
-            break
+                return state == BT.NodeState.SUCCESS
+            return
 
         yield from Yield.wait(throttle_ms)
 


### PR DESCRIPTION
_run_bt_tree only yielded during the RUNNING state. When a behavior tree returned FAILURE (or SUCCESS) on the first tick, the generator completed with zero yields. Callers using `yield from _run_bt_tree()` inside loops (e.g. skill_loop, _cast_skill) would then re-enter immediately without ever ceding control, creating infinite hot loops that starve the event loop.

Add a bare `yield` before returning on both terminal states to guarantee cooperative scheduling.