### PR TITLE
Refactor interrupt flow and tighten throttles CB

### DIFF
--- a/Sources/oazix/CustomBehaviors/primitives/skillbars/custom_behavior_base_utility.py
+++ b/Sources/oazix/CustomBehaviors/primitives/skillbars/custom_behavior_base_utility.py
@@ -297,18 +297,8 @@ class CustomBehaviorBaseUtility():
 
     timer = Timer()
     throttler = ThrottledTimer(50)
-    compute_throttler = ThrottledTimer(300)
+    compute_throttler = ThrottledTimer(80)
     execute_throttler = ThrottledTimer(80)
-
-    # When set, the next act() tick will recompute scores regardless of the
-    # compute_throttler. Used by event-driven skills (e.g. interrupts) to react
-    # faster than the 300ms score cycle without bypassing the execute pipeline.
-    _force_recompute_next_tick: bool = False
-
-    @classmethod
-    def request_score_recompute(cls):
-        """Request the next act() tick to recompute scores immediately."""
-        cls._force_recompute_next_tick = True
 
     def act(self):
         if not self.throttler.IsExpired(): return
@@ -339,12 +329,10 @@ class CustomBehaviorBaseUtility():
         #         hero_ai_options.Following = False
         #         hero_ai_options.Looting = False
 
-        # it is interesting to compute score less often, as the execution :
-        # - if we are executing with EXECUTE_THROUGH_THE_END, most of the time it take more than 300/400 ms with the aftercast.
-        # - if we are executing with STOP_EXECUTION_ONCE_SCORE_NOT_HIGHEST, we don't need huge responsiveness
 
-        if CustomBehaviorBaseUtility._force_recompute_next_tick or self.compute_throttler.IsExpired():
-            CustomBehaviorBaseUtility._force_recompute_next_tick = False
+        
+
+        if self.compute_throttler.IsExpired():
             self.compute_throttler.Reset()
             self.timer.Reset()
             self.__fetch_and_memoized_state()

--- a/Sources/oazix/CustomBehaviors/primitives/skills/interrupt_skill_base.py
+++ b/Sources/oazix/CustomBehaviors/primitives/skills/interrupt_skill_base.py
@@ -3,7 +3,6 @@ from typing import Any, Generator, override
 
 import Py4GW
 from Py4GWCoreLib import GLOBAL_CACHE, Agent, Player, Routines, Range, CombatEvents
-from Py4GWCoreLib.enums import Allegiance
 
 from Sources.oazix.CustomBehaviors.primitives.behavior_state import BehaviorState
 from Sources.oazix.CustomBehaviors.primitives.bus.event_bus import EventBus
@@ -20,20 +19,10 @@ from Sources.oazix.CustomBehaviors.primitives.skills.custom_skill_utility_base i
 
 class InterruptSkillBase(CustomSkillUtilityBase):
     """
-    Base class for interrupt-style skills. Handles all mechanics shared by
-    every interrupt skill so concrete skills only declare what to interrupt
-    and how to score it.
-
-    Responsibilities:
-      - Registers a CombatEvents.on_skill_activated callback for event-driven detection
-      - Calculates cast-time feasibility (Fast Casting + ping + remaining cast time)
-      - Coordinates party members via the shared lock manager
-      - Falls back to polling when the event path misses (e.g. entered range after cast started)
-      - Runs _execute() through the normal engine pipeline (history, metrics, watchdogs, plugins)
-
-    Subclasses implement:
-      - _filter_target(skill_id, activation_seconds) : what casts to interrupt
-      - _compute_score(target_id) : skill-specific scoring (energy, cooldown, etc.)
+    Base class for interrupt-style skills. Scans for enemies currently casting,
+    checks cast-time feasibility (Fast Casting + ping + remaining cast time),
+    coordinates with party members via the shared lock manager, and runs
+    _execute() through the normal engine pipeline.
     """
 
     def __init__(self,
@@ -56,12 +45,9 @@ class InterruptSkillBase(CustomSkillUtilityBase):
         self._lock_ttl_seconds: int = lock_ttl_seconds
         self._min_activation_seconds: float = min_activation_seconds
 
-        self._interrupt_opportunity: tuple[int, int] | None = None  # (agent_id, skill_id)
+        self._pending_target_id: int | None = None  # target selected in _evaluate, consumed in _execute
         self._ping_handler = Py4GW.PingHandler()
         self._shared_lock_manager = CustomBehaviorParty().get_shared_lock_manager()
-        CombatEvents.on_skill_activated(self._on_enemy_cast)
-
-    # --- Abstract subclass hooks -------------------------------------------------
 
     @abstractmethod
     def _filter_target(self, skill_id: int, activation_seconds: float) -> bool:
@@ -72,41 +58,18 @@ class InterruptSkillBase(CustomSkillUtilityBase):
     def _compute_score(self, target_id: int) -> float | None:
         """
         Return the skill's priority score for this target, or None to skip.
-        Subclass is responsible for its own gating (energy, cooldown, etc.)
-        and should use its score_definition primitive.
+        Subclass handles its own gating (energy, cooldown, etc.) using its
+        score_definition primitive.
         """
         pass
 
-    # --- Event-driven detection --------------------------------------------------
-
-    def _on_enemy_cast(self, caster_id: int, skill_id: int, target_id: int):
-        if Agent.GetAllegiance(caster_id)[0] != Allegiance.Enemy: return
-        activation = GLOBAL_CACHE.Skill.Data.GetActivation(skill_id)
-        if activation < self._min_activation_seconds: return
-        if not self._filter_target(skill_id, activation): return
-
-        player_pos = Player.GetXY()
-        enemy_pos = Agent.GetXY(caster_id)
-        dx = player_pos[0] - enemy_pos[0]
-        dy = player_pos[1] - enemy_pos[1]
-        if (dx * dx + dy * dy) > Range.Spellcast.value ** 2: return
-
-        self._interrupt_opportunity = (caster_id, skill_id)
-        # Skip the 300ms score throttle so we react within one execute cycle
-        from Sources.oazix.CustomBehaviors.primitives.skillbars.custom_behavior_base_utility import CustomBehaviorBaseUtility
-        CustomBehaviorBaseUtility.request_score_recompute()
-
-    # --- Feasibility math --------------------------------------------------------
-
-    def _get_fast_casting_level(self) -> int:
+    def _calculate_our_cast_time_ms(self) -> float:
+        fast_casting_level = 0
         for attr in Agent.GetAttributes(Player.GetAgentID()):
             if attr.GetName() == "Fast Casting":
-                return attr.level
-        return 0
-
-    def _calculate_our_cast_time_ms(self) -> float:
-        fc_level = self._get_fast_casting_level()
-        activation_s, _ = Routines.Checks.Skills.apply_fast_casting(self.custom_skill.skill_id, fc_level)
+                fast_casting_level = attr.level
+                break
+        activation_s, _ = Routines.Checks.Skills.apply_fast_casting(self.custom_skill.skill_id, fast_casting_level)
         return activation_s * 1000.0
 
     def _is_feasible(self, target_id: int) -> bool:
@@ -117,19 +80,11 @@ class InterruptSkillBase(CustomSkillUtilityBase):
         if remaining_ms > 0:
             return remaining_ms > our_cast_ms + ping_ms
 
-        # Fallback: use skill activation time as estimate (assume halfway through)
+        # Fallback: assume enemy is halfway through their cast
         casting_skill_id = Agent.GetCastingSkillID(target_id)
         if casting_skill_id == 0: return False
         estimated_remaining = GLOBAL_CACHE.Skill.Data.GetActivation(casting_skill_id) * 500.0
         return estimated_remaining > our_cast_ms + ping_ms
-
-    # --- Polling fallback --------------------------------------------------------
-    # Why this exists: the event callback only fires once per SKILL_ACTIVATED packet.
-    # If an enemy starts casting while we're out of range, the callback rejects the
-    # opportunity (range check). When we walk into range a moment later, no new event
-    # fires — the enemy is still mid-cast but the event has already been consumed.
-    # This polling pass catches that "cast already in progress when we entered range"
-    # scenario, which is common at the start of engagements.
 
     def _detect_casting_enemies(self, sort_key=(TargetingOrder.CASTER_THEN_MELEE,)) -> list[SortableAgentData]:
         return custom_behavior_helpers.Targets.get_all_possible_enemies_ordered_by_priority_raw(
@@ -143,54 +98,33 @@ class InterruptSkillBase(CustomSkillUtilityBase):
             range_to_count_enemies=GLOBAL_CACHE.Skill.Data.GetAoERange(self.custom_skill.skill_id)
         )
 
-    # --- Target selection --------------------------------------------------------
-
-    @staticmethod
-    def _lock_key_for(skill_name: str, agent_id: int) -> str:
-        return f"{skill_name}_{agent_id}"
+    def _lock_key(self, agent_id: int) -> str:
+        return f"{self.custom_skill.skill_name}_{agent_id}"
 
     def _find_unlocked_target(self) -> int | None:
-        # Event-driven path first
-        if self._interrupt_opportunity is not None:
-            caster_id, _ = self._interrupt_opportunity
-            lock_key = self._lock_key_for(self.custom_skill.skill_name, caster_id)
-            if (Agent.IsCasting(caster_id) and self._is_feasible(caster_id)
-                    and not self._shared_lock_manager.is_lock_taken(lock_key)):
-                return caster_id
-            self._interrupt_opportunity = None
-
-        # Polling fallback: scan casting enemies and take the first unlocked feasible one
         for t in self._detect_casting_enemies():
-            lock_key = self._lock_key_for(self.custom_skill.skill_name, t.agent_id)
-            if self._is_feasible(t.agent_id) and not self._shared_lock_manager.is_lock_taken(lock_key):
-                self._interrupt_opportunity = (t.agent_id, Agent.GetCastingSkillID(t.agent_id))
+            if self._is_feasible(t.agent_id) and not self._shared_lock_manager.is_lock_taken(self._lock_key(t.agent_id)):
                 return t.agent_id
         return None
-
-    # --- Default _evaluate: find target, delegate scoring to subclass ------------
 
     @override
     def _evaluate(self, current_state: BehaviorState, previously_attempted_skills: list[CustomSkill]) -> float | None:
         target_id = self._find_unlocked_target()
+        self._pending_target_id = target_id
         if target_id is None: return None
         return self._compute_score(target_id)
 
-    # --- Standard _execute through the normal pipeline ---------------------------
-
     @override
     def _execute(self, state: BehaviorState) -> Generator[Any | None, Any | None, BehaviorResult]:
-        opp = self._interrupt_opportunity
-        self._interrupt_opportunity = None
+        target_id = self._pending_target_id
+        self._pending_target_id = None
 
-        if opp is None: return BehaviorResult.ACTION_SKIPPED
-        target_id, _ = opp
-
+        if target_id is None: return BehaviorResult.ACTION_SKIPPED
         if not Agent.IsCasting(target_id): return BehaviorResult.ACTION_SKIPPED
         if not self._is_feasible(target_id): return BehaviorResult.ACTION_SKIPPED
 
-        lock_key = self._lock_key_for(self.custom_skill.skill_name, target_id)
         if not self._shared_lock_manager.try_aquire_lock(
-                lock_key,
+                self._lock_key(target_id),
                 timeout_seconds=self._lock_ttl_seconds,
                 lock_type=ShareLockType.SKILLS):
             return BehaviorResult.ACTION_SKIPPED

--- a/Sources/oazix/CustomBehaviors/skillbars/mesmer_esurgery.py
+++ b/Sources/oazix/CustomBehaviors/skillbars/mesmer_esurgery.py
@@ -2,7 +2,6 @@ from typing import override
 
 from Sources.oazix.CustomBehaviors.primitives.behavior_state import BehaviorState
 from Sources.oazix.CustomBehaviors.primitives.scores.score_per_agent_quantity_definition import ScorePerAgentQuantityDefinition
-from Sources.oazix.CustomBehaviors.primitives.scores.score_per_energy_definition import ScorePerEnergyDefinition
 from Sources.oazix.CustomBehaviors.primitives.scores.score_per_health_gravity_definition import ScorePerHealthGravityDefinition
 from Sources.oazix.CustomBehaviors.primitives.scores.score_static_definition import ScoreStaticDefinition
 from Sources.oazix.CustomBehaviors.primitives.skillbars.custom_behavior_base_utility import CustomBehaviorBaseUtility
@@ -41,7 +40,7 @@ class MesmerESurgery_UtilitySkillBar(CustomBehaviorBaseUtility):
         # interrupt
         self.cry_of_pain_utility: CustomSkillUtilityBase = CryOfPainUtility(event_bus=self.event_bus, current_build=in_game_build, score_definition=ScoreStaticDefinition(90))
         self.cry_of_frustration_utility: CustomSkillUtilityBase = CryOfFrustrationUtility(event_bus=self.event_bus, current_build=in_game_build, score_definition=ScoreStaticDefinition(91))
-        self.power_drain_utility: CustomSkillUtilityBase = PowerDrainUtility(event_bus=self.event_bus, current_build=in_game_build, score_definition=ScorePerEnergyDefinition(score_nominal=40, score_boosted=100, block_threshold=0.85, floor_threshold=0.30))
+        self.power_drain_utility: CustomSkillUtilityBase = PowerDrainUtility(event_bus=self.event_bus, current_build=in_game_build)
 
         # hex
         self.mistrust_utility: CustomSkillUtilityBase = MistrustUtility(event_bus=self.event_bus, current_build=in_game_build, score_definition=ScorePerAgentQuantityDefinition(lambda enemy_qte: 70 if enemy_qte >= 3 else 40 if enemy_qte <= 2 else 0), mana_required_to_cast=10)

--- a/Sources/oazix/CustomBehaviors/skillbars/mesmer_ineptitude.py
+++ b/Sources/oazix/CustomBehaviors/skillbars/mesmer_ineptitude.py
@@ -3,7 +3,6 @@ from typing import override
 from Py4GWCoreLib.GlobalCache import GLOBAL_CACHE
 from Sources.oazix.CustomBehaviors.primitives.behavior_state import BehaviorState
 from Sources.oazix.CustomBehaviors.primitives.scores.score_per_agent_quantity_definition import ScorePerAgentQuantityDefinition
-from Sources.oazix.CustomBehaviors.primitives.scores.score_per_energy_definition import ScorePerEnergyDefinition
 from Sources.oazix.CustomBehaviors.primitives.scores.score_per_health_gravity_definition import ScorePerHealthGravityDefinition
 from Sources.oazix.CustomBehaviors.primitives.scores.score_static_definition import ScoreStaticDefinition
 from Sources.oazix.CustomBehaviors.primitives.skillbars.custom_behavior_base_utility import CustomBehaviorBaseUtility
@@ -44,7 +43,7 @@ class MesmerIneptitude_UtilitySkillBar(CustomBehaviorBaseUtility):
 
         # interrupt
         self.cry_of_pain_utility: CustomSkillUtilityBase = CryOfPainUtility(event_bus=self.event_bus, current_build=in_game_build, score_definition=ScoreStaticDefinition(90))
-        self.power_drain_utility: CustomSkillUtilityBase = PowerDrainUtility(event_bus=self.event_bus, current_build=in_game_build, score_definition=ScorePerEnergyDefinition(score_nominal=40, score_boosted=100, block_threshold=0.85, floor_threshold=0.30))
+        self.power_drain_utility: CustomSkillUtilityBase = PowerDrainUtility(event_bus=self.event_bus, current_build=in_game_build)
 
 #         Cast Glyph of Lesser Energy↦Arcane Conundrum↦Cry of Pain on the largest group of foes, preferably hitting casters.
 #         Deal damage against balled up attacking foes utilizing Ineptitude, Wandering Eye and Signet of Clumsiness.


### PR DESCRIPTION
Reduce score compute throttle from 300ms to 80ms and remove the ad-hoc "force recompute next tick" mechanism so scoring runs at the same cadence as execution.

Simplify InterruptSkillBase by removing the event-driven on_skill_activated path and Allegiance import, using a polling-based target selection instead; introduce a pending_target_id flow consumed by _execute, consolidate lock key handling, and inline fast-casting lookup.

Also remove energy-score wiring for PowerDrainUtility in two Mesmer skillbars (now instantiated without ScorePerEnergyDefinition). These changes simplify interrupt logic and align responsiveness with the execution pipeline.