### PR TITLE
Fix FSM null guards and add SharedMemory SameMap helpers

### DIFF
--- a/Py4GWCoreLib/GlobalCache/SharedMemory.py
+++ b/Py4GWCoreLib/GlobalCache/SharedMemory.py
@@ -47,6 +47,10 @@ from HeroAI.following import FollowFormationPublisher
 from ..py4gwcorelib_src.FrameCache import frame_cache
 
 
+def _account_key(self, account: AccountStruct):
+    return (account.AccountEmail, int(account.AgentData.AgentID))
+
+
 #region SharedMemoryManager    
 class Py4GWSharedMemoryManager:
     _instance = None  # Singleton instance
@@ -100,6 +104,47 @@ class Py4GWSharedMemoryManager:
     @frame_cache(category="SharedMemory", source_lib="GetAccountData")
     def GetAccountData(self, index: int) -> AccountStruct:
         return self.GetAllAccounts().GetAccountData(index)
+
+    @frame_cache(category="SharedMemory", source_lib="SameMapAsAccount", key=_account_key)
+    def SameMapAsAccount(self, account: AccountStruct) -> bool:
+        if not Map.IsMapReady():
+            return False
+
+        own_map_id = Map.GetMapID()
+        own_region = Map.GetRegion()[0]
+        own_district = Map.GetDistrict()
+        own_language = Map.GetLanguage()[0]
+        return (
+            own_map_id == account.AgentData.Map.MapID
+            and own_region == account.AgentData.Map.Region
+            and own_district == account.AgentData.Map.District
+            and own_language == account.AgentData.Map.Language
+        )
+
+    @frame_cache(category="SharedMemory", source_lib="SameMapOrPartyAsAccount", key=_account_key)
+    def SameMapOrPartyAsAccount(self, account: AccountStruct) -> bool:
+        if not Map.IsMapReady():
+            return False
+
+        own_map_id = Map.GetMapID()
+        own_region = Map.GetRegion()[0]
+        own_district = Map.GetDistrict()
+        own_language = Map.GetLanguage()[0]
+        party_members = [
+            Party.Players.GetAgentIDByLoginNumber(party_member.login_number)
+            for party_member in Party.GetPlayers()
+        ]
+
+        same_map = (
+            own_map_id == account.AgentData.Map.MapID
+            and own_district == account.AgentData.Map.District
+            and own_language == account.AgentData.Map.Language
+        )
+
+        if same_map and account.AgentData.AgentID in party_members and account.AgentPartyData.PartyID == Party.GetPartyID():
+            return True
+
+        return same_map and own_region == account.AgentData.Map.Region
             
     #region Messaging
     @frame_cache(category="SharedMemory", source_lib="GetAllMessages")

--- a/Py4GWCoreLib/py4gwcorelib_src/FSM.py
+++ b/Py4GWCoreLib/py4gwcorelib_src/FSM.py
@@ -580,6 +580,10 @@ class FSM:
                     self.managed_coroutines.remove(routine)
                 except ValueError:
                     pass
+
+        # A managed coroutine may stop/reset FSM mid-tick.
+        if not self.current_state:
+            return
                 
         if self.paused:
             if self.log_actions:
@@ -590,6 +594,10 @@ class FSM:
         if self.log_actions:
             ConsoleLog("FSM", f"{self.name}: Executing state: {self.current_state.name}", Py4GW.Console.MessageType.Info)
         self.current_state.execute()
+
+        # State execution can indirectly clear/replace current_state.
+        if not self.current_state:
+            return
 
         if not self.current_state.can_exit():
             return


### PR DESCRIPTION
- FSM: Restore null guards for self.current_state in execute_step() Prevents native crash when managed coroutines reset/stop FSM mid-tick.
- SharedMemory: Add SameMapAsAccount and SameMapOrPartyAsAccount with frame_cache support and explicit _account_key helper.