### PR TITLE
Fix Player.IsPlayerLoaded() returning False when player is valid

### DIFF
--- a/Py4GWCoreLib/Player.py
+++ b/Py4GWCoreLib/Player.py
@@ -142,7 +142,7 @@ class Player:
         if not Agent.GetInstanceUptime(agent_id) > 750:
             return False
             
-        return False
+        return True
     
     @staticmethod
     def _require_player_loaded(default=None):


### PR DESCRIPTION
The fallback path (when player_number is not in the party list) correctly validates agent_id and uptime > 750ms, but then returns False instead of True. This causes IsPlayerLoaded() to always fail for the controlling player when they are not found via login_number lookup.