### PR TITLE
HeroAi Updates

### DIFF
--- a/HeroAI/combat.py
+++ b/HeroAI/combat.py
@@ -6,7 +6,7 @@ from Py4GWCoreLib import Weapon, Effects
 from Py4GWCoreLib.enums import SPIRIT_BUFF_MAP, ModelID
 from .custom_skill import CustomSkillClass
 from .targeting import TargetLowestAlly, TargetLowestAllyEnergy, TargetClusteredEnemy, TargetLowestAllyCaster, TargetLowestAllyMartial, TargetLowestAllyMelee, TargetLowestAllyRanged, GetAllAlliesArray
-from .targeting import GetEnemyAttacking, GetEnemyCasting, GetEnemyCastingSpell, GetEnemyInjured, GetEnemyConditioned, GetEnemyHealthy
+from .targeting import GetEnemyAttacking, GetEnemyCasting, GetEnemyCastingSpell, GetEnemyCastingSpellOrChant, GetEnemyInjured, GetEnemyConditioned, GetEnemyHealthy
 from .targeting import GetEnemyHexed, GetEnemyDegenHexed, GetEnemyEnchanted, GetEnemyMoving, GetEnemyKnockedDown
 from .targeting import GetEnemyBleeding, GetEnemyPoisoned, GetEnemyCrippled
 from .types import SkillNature, Skilltarget, SkillType
@@ -100,7 +100,7 @@ class CombatClass:
         self.aftercast_timer.Start()
         self.ping_handler = Py4GW.PingHandler()
         self.oldCalledTarget: int = 0
-        
+
         self.in_aggro: bool = False
         self.is_targeting_enabled: bool = False
         self.is_combat_enabled: bool = False
@@ -540,6 +540,10 @@ class CombatClass:
             v_target = GetEnemyCastingSpell(self.get_combat_distance())
             if v_target == 0 and not targeting_strict:
                 v_target = get_nearest_enemy()
+        elif target_allegiance == Skilltarget.EnemyCastingSpellOrChant:
+            v_target = GetEnemyCastingSpellOrChant(self.get_combat_distance())
+            if v_target == 0 and not targeting_strict:
+                v_target = get_nearest_enemy()
         elif target_allegiance == Skilltarget.EnemyInjured:
             v_target = GetEnemyInjured(self.get_combat_distance())
             if v_target == 0 and not targeting_strict:
@@ -883,6 +887,7 @@ class CombatClass:
         feature_count += (1 if Conditions.LessLife > 0 else 0)
         feature_count += (1 if Conditions.MoreLife > 0 else 0)
         feature_count += (1 if Conditions.LessEnergy > 0 else 0)
+        feature_count += (1 if Conditions.LessSelfEnergyPercentage > 0 else 0)
         feature_count += (1 if Conditions.Overcast > 0 else 0)
         feature_count += (1 if Conditions.IsPartyWide else 0)
         feature_count += (1 if Conditions.RequiresSpiritInEarshot else 0)
@@ -1064,6 +1069,11 @@ class CombatClass:
                     number_of_features += 1
             else:
                 number_of_features += 1 #henchmen, allies, pets or something else thats not reporting energy
+
+        if Conditions.LessSelfEnergyPercentage > 0:
+            # Agent.GetEnergy returns a 0.0-1.0 fraction of max energy; threshold uses the same scale.
+            if Agent.GetEnergy(Player.GetAgentID()) <= Conditions.LessSelfEnergyPercentage:
+                number_of_features += 1
 
         if Conditions.Overcast != 0:
             if Player.GetAgentID() == vTarget:

--- a/HeroAI/combat.py
+++ b/HeroAI/combat.py
@@ -5,7 +5,7 @@ from Py4GWCoreLib import Player, GLOBAL_CACHE, SpiritModelID, Timer, Agent, Rout
 from Py4GWCoreLib import Weapon, Effects
 from Py4GWCoreLib.enums import SPIRIT_BUFF_MAP, ModelID
 from .custom_skill import CustomSkillClass
-from .targeting import TargetLowestAlly, TargetLowestAllyEnergy, TargetClusteredEnemy, TargetLowestAllyCaster, TargetLowestAllyMartial, TargetLowestAllyMelee, TargetLowestAllyRanged, GetAllAlliesArray
+from .targeting import TargetLowestAlly, TargetLowestAllyEnergy, TargetClusteredEnemy, TargetLowestAllyCaster, TargetLowestAllyMartial, TargetLowestAllyMelee, TargetLowestAllyRanged, GetAllAlliesArray, TargetAllyWeaponSpell
 from .targeting import GetEnemyAttacking, GetEnemyCasting, GetEnemyCastingSpell, GetEnemyCastingSpellOrChant, GetEnemyInjured, GetEnemyConditioned, GetEnemyHealthy
 from .targeting import GetEnemyHexed, GetEnemyDegenHexed, GetEnemyEnchanted, GetEnemyMoving, GetEnemyKnockedDown
 from .targeting import GetEnemyBleeding, GetEnemyPoisoned, GetEnemyCrippled
@@ -544,6 +544,10 @@ class CombatClass:
             v_target = GetEnemyCastingSpellOrChant(self.get_combat_distance())
             if v_target == 0 and not targeting_strict:
                 v_target = get_nearest_enemy()
+        elif target_allegiance == Skilltarget.AllyWeaponSpell:
+            v_target = TargetAllyWeaponSpell(self.skills[slot].skill_id, self.get_combat_distance())
+            if v_target == 0 and not targeting_strict:
+                v_target = get_lowest_ally()
         elif target_allegiance == Skilltarget.EnemyInjured:
             v_target = GetEnemyInjured(self.get_combat_distance())
             if v_target == 0 and not targeting_strict:

--- a/HeroAI/custom_skill_src/mesmer.py
+++ b/HeroAI/custom_skill_src/mesmer.py
@@ -40,7 +40,7 @@ class MesmerSkills:
         skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Power_Return")
         skill.SkillType = SkillType.Spell.value
-        skill.TargetAllegiance = Skilltarget.EnemyCastingSpell.value
+        skill.TargetAllegiance = Skilltarget.EnemyCastingSpellOrChant.value
         skill.Nature = SkillNature.Interrupt.value
         skill.Conditions.IsCasting = True
         skill_data[skill.SkillID] = skill
@@ -243,7 +243,7 @@ class MesmerSkills:
         skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Power_Block")
         skill.SkillType = SkillType.Spell.value
-        skill.TargetAllegiance = Skilltarget.EnemyCastingSpell.value
+        skill.TargetAllegiance = Skilltarget.EnemyCastingSpellOrChant.value
         skill.Nature = SkillNature.Interrupt.value
         skill.Conditions.IsCasting = True
         skill_data[skill.SkillID] = skill
@@ -251,7 +251,7 @@ class MesmerSkills:
         skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Power_Flux")
         skill.SkillType = SkillType.Hex.value
-        skill.TargetAllegiance = Skilltarget.EnemyCastingSpell.value
+        skill.TargetAllegiance = Skilltarget.EnemyCastingSpellOrChant.value
         skill.Nature = SkillNature.Interrupt.value
         skill.Conditions.IsCasting = True
         skill_data[skill.SkillID] = skill
@@ -259,7 +259,7 @@ class MesmerSkills:
         skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Power_Leak")
         skill.SkillType = SkillType.Spell.value
-        skill.TargetAllegiance = Skilltarget.EnemyCastingSpell.value
+        skill.TargetAllegiance = Skilltarget.EnemyCastingSpellOrChant.value
         skill.Nature = SkillNature.Interrupt.value
         skill.Conditions.IsCasting = True
         skill_data[skill.SkillID] = skill
@@ -267,7 +267,7 @@ class MesmerSkills:
         skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Power_Lock")
         skill.SkillType = SkillType.Spell.value
-        skill.TargetAllegiance = Skilltarget.EnemyCastingSpell.value
+        skill.TargetAllegiance = Skilltarget.EnemyCastingSpellOrChant.value
         skill.Nature = SkillNature.Interrupt.value
         skill.Conditions.IsCasting = True
         skill_data[skill.SkillID] = skill
@@ -275,7 +275,7 @@ class MesmerSkills:
         skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Power_Spike")
         skill.SkillType = SkillType.Spell.value
-        skill.TargetAllegiance = Skilltarget.EnemyCastingSpell.value
+        skill.TargetAllegiance = Skilltarget.EnemyCastingSpellOrChant.value
         skill.Nature = SkillNature.Interrupt.value
         skill.Conditions.IsCasting = True
         skill_data[skill.SkillID] = skill
@@ -887,15 +887,16 @@ class MesmerSkills:
         skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Power_Drain")
         skill.SkillType = SkillType.Spell.value
-        skill.TargetAllegiance = Skilltarget.EnemyCastingSpell.value
+        skill.TargetAllegiance = Skilltarget.EnemyCastingSpellOrChant.value
         skill.Nature = SkillNature.Interrupt.value
         skill.Conditions.IsCasting = True
+        skill.Conditions.LessSelfEnergyPercentage = 0.70
         skill_data[skill.SkillID] = skill
 
         skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Power_Leech")
         skill.SkillType = SkillType.Spell.value
-        skill.TargetAllegiance = Skilltarget.EnemyCastingSpell.value
+        skill.TargetAllegiance = Skilltarget.EnemyCastingSpellOrChant.value
         skill.Nature = SkillNature.Interrupt.value
         skill.Conditions.IsCasting = True
         skill_data[skill.SkillID] = skill

--- a/HeroAI/custom_skill_src/ritualist.py
+++ b/HeroAI/custom_skill_src/ritualist.py
@@ -858,7 +858,7 @@ class RitualistSkills:
         skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Xinraes_Weapon")
         skill.SkillType = SkillType.WeaponSpell.value
-        skill.TargetAllegiance = Skilltarget.Ally.value
+        skill.TargetAllegiance = Skilltarget.AllyWeaponSpell.value
         skill.Nature = SkillNature.Buff.value
         skill_data[skill.SkillID] = skill
 

--- a/HeroAI/custom_skill_src/ritualist.py
+++ b/HeroAI/custom_skill_src/ritualist.py
@@ -725,6 +725,7 @@ class RitualistSkills:
         skill.TargetAllegiance = Skilltarget.Self.value
         skill.Nature = SkillNature.Healing.value
         skill.Conditions.IsOutOfCombat = False
+        skill.Conditions.MinSpiritHpFractionForRecast = 0.20
         skill_data[skill.SkillID] = skill
 
         skill = CustomSkill()

--- a/HeroAI/custom_skill_src/skill_types.py
+++ b/HeroAI/custom_skill_src/skill_types.py
@@ -70,6 +70,11 @@ class CastConditions:
         self.PartyWideArea = 0
         self.UniqueProperty = False
         self.IsOutOfCombat = False
+        # Spirit skills: when > 0, BuildMgr.SpiritBuffExists treats an existing
+        # spirit of this skill as absent once its HP drops below this fraction,
+        # allowing a preemptive recast before the spirit dies. 0.0 = disabled
+        # (default), matches the pre-change binary alive/dead gate.
+        self.MinSpiritHpFractionForRecast = 0.0
 
         # combat field checks
         self.EnemiesInRange = 0

--- a/HeroAI/custom_skill_src/skill_types.py
+++ b/HeroAI/custom_skill_src/skill_types.py
@@ -48,6 +48,11 @@ class CastConditions:
         self.LessLife = 0.0
         self.MoreLife = 0.0
         self.LessEnergy = 0.0
+        # Hard cap on caster's own energy. 0.0 disables. When > 0, the skill is only
+        # eligible while Agent.GetEnergy(player) (a 0.0-1.0 fraction of max) is at or
+        # below this value. Use for energy-return interrupts like Power Drain so the
+        # cast is skipped when the caster is already near full.
+        self.LessSelfEnergyPercentage = 0.0
         self.Overcast = 0.0
         self.Overcast = 0.0
         self.SacrificeHealth = 0.0

--- a/HeroAI/targeting.py
+++ b/HeroAI/targeting.py
@@ -254,3 +254,107 @@ def GetEnemyKnockedDown(max_distance=4500.0, aggressive_only = False):
 
 def GetEnemyWithEffect(effect_skill_id, max_distance=4500.0, aggressive_only = False):
     return _filter_blacklisted(Routines.Targeting.GetEnemyWithEffect(effect_skill_id, max_distance, aggressive_only))
+
+
+def TargetMeleeOrMartialClusterEnemy(
+    skill_id: int,
+    *,
+    require_attacking: bool = False,
+    max_distance: float = Range.Spellcast.value,
+) -> int:
+    """Pick the densest-cluster enemy for a melee-group AoE skill.
+
+    Candidate pool is (IsMelee OR IsMartial OR IsAttacking); falls back to
+    any enemy when no IsMelee/IsMartial is in range. Ranks by cluster size
+    then player-distance. require_attacking=True hard-requires IsAttacking.
+    """
+    player_x, player_y = Player.GetXY()
+    enemy_array = Routines.Agents.GetFilteredEnemyArray(player_x, player_y, max_distance)
+    enemy_array = AgentArray.Filter.ByCondition(
+        enemy_array,
+        lambda agent_id: Agent.IsValid(agent_id) and not Agent.IsDead(agent_id),
+    )
+    if not enemy_array:
+        return 0
+
+    aoe_range = GLOBAL_CACHE.Skill.Data.GetAoERange(skill_id) or Range.Nearby.value
+
+    melees_present = any(
+        Agent.IsMelee(agent_id) or Agent.IsMartial(agent_id)
+        for agent_id in enemy_array
+    )
+
+    if melees_present:
+        candidates = [
+            agent_id for agent_id in enemy_array
+            if Agent.IsMelee(agent_id)
+            or Agent.IsMartial(agent_id)
+            or Agent.IsAttacking(agent_id)
+        ]
+    else:
+        candidates = list(enemy_array)
+
+    if require_attacking:
+        candidates = [agent_id for agent_id in candidates if Agent.IsAttacking(agent_id)]
+
+    if not candidates:
+        return 0
+
+    player_pos = (player_x, player_y)
+    scored: list[tuple[int, float, int]] = []
+    for agent_id in candidates:
+        target_x, target_y = Agent.GetXY(agent_id)
+        nearby = Routines.Agents.GetFilteredEnemyArray(target_x, target_y, aoe_range)
+        nearby = AgentArray.Filter.ByCondition(
+            nearby,
+            lambda eid: Agent.IsValid(eid) and not Agent.IsDead(eid),
+        )
+        cluster_score = max(0, len(nearby) - 1)
+        distance = Utils.Distance(player_pos, Agent.GetXY(agent_id))
+        scored.append((cluster_score, distance, agent_id))
+
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    return _filter_blacklisted(scored[0][2])
+
+
+def TargetCasterClusterEnemy(
+    skill_id: int,
+    *,
+    max_distance: float = Range.Spellcast.value,
+) -> int:
+    """Pick the densest-caster-cluster enemy for a caster-targeted AoE hex.
+
+    Candidate pool is IsCaster only. Ranks by caster-cluster size DESC
+    (adjacent casters within the skill's AoE range), then player-distance
+    ASC. Returns 0 if no caster is in range.
+    """
+    player_x, player_y = Player.GetXY()
+    enemy_array = Routines.Agents.GetFilteredEnemyArray(player_x, player_y, max_distance)
+    enemy_array = AgentArray.Filter.ByCondition(
+        enemy_array,
+        lambda agent_id: Agent.IsValid(agent_id) and not Agent.IsDead(agent_id),
+    )
+    if not enemy_array:
+        return 0
+
+    casters = [agent_id for agent_id in enemy_array if Agent.IsCaster(agent_id)]
+    if not casters:
+        return 0
+
+    aoe_range = GLOBAL_CACHE.Skill.Data.GetAoERange(skill_id) or Range.Nearby.value
+
+    player_pos = (player_x, player_y)
+    scored: list[tuple[int, float, int]] = []
+    for agent_id in casters:
+        target_x, target_y = Agent.GetXY(agent_id)
+        nearby = Routines.Agents.GetFilteredEnemyArray(target_x, target_y, aoe_range)
+        nearby = AgentArray.Filter.ByCondition(
+            nearby,
+            lambda eid: Agent.IsValid(eid) and not Agent.IsDead(eid) and Agent.IsCaster(eid),
+        )
+        cluster_score = max(0, len(nearby) - 1)
+        distance = Utils.Distance(player_pos, Agent.GetXY(agent_id))
+        scored.append((cluster_score, distance, agent_id))
+
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    return _filter_blacklisted(scored[0][2])

--- a/HeroAI/targeting.py
+++ b/HeroAI/targeting.py
@@ -256,6 +256,59 @@ def GetEnemyWithEffect(effect_skill_id, max_distance=4500.0, aggressive_only = F
     return _filter_blacklisted(Routines.Targeting.GetEnemyWithEffect(effect_skill_id, max_distance, aggressive_only))
 
 
+def TargetAllyWeaponSpell(weapon_spell_skill_id, max_distance=Range.Spellcast.value, refresh_window_ms=1000):
+    # Picks the best ally to receive `weapon_spell_skill_id`.
+    # Eligible allies have no conflicting weapon spell, or already carry this same
+    # weapon spell with <= refresh_window_ms remaining (refresh tier). Scoring
+    # prefers allies about to take damage: most enemies within Earshot first,
+    # then lowest HP, then closest to the caster.
+    if not weapon_spell_skill_id:
+        return 0
+
+    ally_array = GetAllAlliesArray(max_distance) or []
+    if not ally_array:
+        return 0
+
+    def _is_refresh_eligible(agent_id):
+        if not Agent.IsWeaponSpelled(agent_id):
+            return True
+        if not Routines.Checks.Agents.HasEffect(agent_id, weapon_spell_skill_id):
+            return False
+        remaining_ms = GLOBAL_CACHE.Effects.GetEffectTimeRemaining(agent_id, weapon_spell_skill_id)
+        return remaining_ms <= refresh_window_ms
+
+    candidates = [
+        agent_id for agent_id in ally_array
+        if Agent.IsValid(agent_id)
+        and Routines.Checks.Agents.IsAlive(agent_id)
+        and _is_refresh_eligible(agent_id)
+    ]
+    if not candidates:
+        return 0
+
+    def _enemies_near(agent_id):
+        ally_x, ally_y = Agent.GetXY(agent_id)
+        nearby = Routines.Agents.GetFilteredEnemyArray(ally_x, ally_y, Range.Earshot.value)
+        nearby = AgentArray.Filter.ByCondition(
+            nearby,
+            lambda enemy_id: Agent.IsValid(enemy_id) and not Agent.IsDead(enemy_id),
+        )
+        return len(nearby)
+
+    player_pos = Player.GetXY()
+    scored = [
+        (
+            -_enemies_near(agent_id),
+            Agent.GetHealth(agent_id),
+            Utils.Distance(player_pos, Agent.GetXY(agent_id)),
+            agent_id,
+        )
+        for agent_id in candidates
+    ]
+    scored.sort()
+    return scored[0][3]
+
+
 def TargetMeleeOrMartialClusterEnemy(
     skill_id: int,
     *,

--- a/HeroAI/targeting.py
+++ b/HeroAI/targeting.py
@@ -209,6 +209,9 @@ def GetEnemyCasting(max_distance=4500.0, aggressive_only = False):
 def GetEnemyCastingSpell(max_distance=4500.0, aggressive_only = False):
     return _filter_blacklisted(Routines.Targeting.GetEnemyCastingSpell(max_distance, aggressive_only))
 
+def GetEnemyCastingSpellOrChant(max_distance=4500.0, aggressive_only=False):
+    return _filter_blacklisted(Routines.Targeting.GetEnemyCastingSpellOrChant(max_distance, aggressive_only))
+
 def GetEnemyInjured(max_distance=4500.0, aggressive_only = False):
     return _filter_blacklisted(Routines.Targeting.GetEnemyInjured(max_distance, aggressive_only))
 

--- a/HeroAI/targeting.py
+++ b/HeroAI/targeting.py
@@ -69,6 +69,13 @@ def SortAlliesByPartyPosition(agent_array):
 
     return sorted(agent_array or [], key=sort_key)
 
+def SortAlliesByLowestHp(agent_array):
+    """Sort allies by current HP ascending, with party position as a stable
+    tiebreak. Python's sort is stable, so equal-HP entries preserve the order
+    from SortAlliesByPartyPosition (players -> heroes -> pet-owners)."""
+    position_sorted = SortAlliesByPartyPosition(agent_array)
+    return sorted(position_sorted, key=lambda agent_id: Agent.GetHealth(agent_id))
+
 def TargetAllyByPredicate(
     predicate=None,
     other_ally=False,
@@ -101,10 +108,10 @@ def TargetLowestAlly(other_ally=False,filter_skill_id=0):
     spirit_pet_array = FilterAllyArray(spirit_pet_array, distance, other_ally, filter_skill_id)
     spirit_pet_array = AgentArray.Filter.ByCondition(spirit_pet_array, lambda agent_id: not Agent.IsSpawned(agent_id)) #filter spirits
     ally_array = AgentArray.Manipulation.Merge(ally_array, spirit_pet_array) #added Pets
-    
-    ally_array = SortAlliesByPartyPosition(ally_array)
+
+    ally_array = SortAlliesByLowestHp(ally_array)
     return Utils.GetFirstFromArray(ally_array)
-    
+
 
 def TargetLowestAllyEnergy(other_ally=False, filter_skill_id=0, less_energy=1.0):
     global BLOOD_IS_POWER, BLOOD_RITUAL
@@ -142,7 +149,7 @@ def TargetLowestAllyCaster(other_ally=False, filter_skill_id=0):
     ally_array = FilterAllyArray(ally_array, distance, other_ally, filter_skill_id)
     ally_array = AgentArray.Filter.ByCondition(ally_array, lambda agent_id: Routines.Checks.Agents.IsCaster(agent_id))
 
-    ally_array = SortAlliesByPartyPosition(ally_array)
+    ally_array = SortAlliesByLowestHp(ally_array)
     return Utils.GetFirstFromArray(ally_array)
 
 
@@ -154,13 +161,13 @@ def TargetLowestAllyMartial(other_ally=False, filter_skill_id=0):
     ally_array = FilterAllyArray(ally_array, distance, other_ally, filter_skill_id)
     ally_array = AgentArray.Filter.ByCondition(ally_array, lambda agent_id: Routines.Checks.Agents.IsMartial(agent_id))
     ally_array = AgentArray.Filter.ByCondition(ally_array, lambda agent_id: not HasIllusionaryWeaponry(agent_id))
-    
+
     spirit_pet_array = AgentArray.GetSpiritPetArray()
     spirit_pet_array = FilterAllyArray(spirit_pet_array, distance, other_ally, filter_skill_id)
     spirit_pet_array = AgentArray.Filter.ByCondition(spirit_pet_array, lambda agent_id: not Agent.IsSpawned(agent_id)) #filter spirits
     ally_array = AgentArray.Manipulation.Merge(ally_array, spirit_pet_array) #added Pets
-    
-    ally_array = SortAlliesByPartyPosition(ally_array)
+
+    ally_array = SortAlliesByLowestHp(ally_array)
     return Utils.GetFirstFromArray(ally_array)
 
 
@@ -172,13 +179,13 @@ def TargetLowestAllyMelee(other_ally=False, filter_skill_id=0):
     ally_array = FilterAllyArray(ally_array, distance, other_ally, filter_skill_id)
     ally_array = AgentArray.Filter.ByCondition(ally_array, lambda agent_id: Routines.Checks.Agents.IsMelee(agent_id))
     ally_array = AgentArray.Filter.ByCondition(ally_array, lambda agent_id: not HasIllusionaryWeaponry(agent_id))
-    
+
     spirit_pet_array = AgentArray.GetSpiritPetArray()
     spirit_pet_array = FilterAllyArray(spirit_pet_array, distance, other_ally, filter_skill_id)
     spirit_pet_array = AgentArray.Filter.ByCondition(spirit_pet_array, lambda agent_id: not Agent.IsSpawned(agent_id)) #filter spirits
     ally_array = AgentArray.Manipulation.Merge(ally_array, spirit_pet_array) #added Pets
-    
-    ally_array = SortAlliesByPartyPosition(ally_array)
+
+    ally_array = SortAlliesByLowestHp(ally_array)
     return Utils.GetFirstFromArray(ally_array)
 
 
@@ -188,11 +195,11 @@ def TargetLowestAllyRanged(other_ally=False, filter_skill_id=0):
     ally_array = AgentArray.GetAllyArray()
     ally_array = FilterAllyArray(ally_array, distance, other_ally, filter_skill_id)
     ally_array = AgentArray.Filter.ByCondition(ally_array, lambda agent_id: Routines.Checks.Agents.IsRanged(agent_id))
-    
-    ally_array = SortAlliesByPartyPosition(ally_array)
+
+    ally_array = SortAlliesByLowestHp(ally_array)
     return Utils.GetFirstFromArray(ally_array)
 
-   
+
 def TargetNearestItem():
     return Routines.Targeting.TargetNearestItem()
 

--- a/HeroAI/types.py
+++ b/HeroAI/types.py
@@ -134,6 +134,7 @@ class Skilltarget (IntEnum):
     EnemyPoisoned = 34
     EnemyCrippled = 35
     EnemyHealthy = 36
+    EnemyCastingSpellOrChant = 37
 
 
 

--- a/HeroAI/types.py
+++ b/HeroAI/types.py
@@ -135,6 +135,7 @@ class Skilltarget (IntEnum):
     EnemyCrippled = 35
     EnemyHealthy = 36
     EnemyCastingSpellOrChant = 37
+    AllyWeaponSpell = 38
 
 
 

--- a/Py4GWCoreLib/BuildMgr.py
+++ b/Py4GWCoreLib/BuildMgr.py
@@ -1051,6 +1051,18 @@ class BuildMgr:
         if not self._is_spirit_skill(skill_id):
             return False
 
+        # Allow the skill's metadata to request HP-aware recast: when the spirit's
+        # current HP fraction drops below `MinSpiritHpFractionForRecast`, treat it
+        # as absent so the caller can refresh before the spirit naturally dies.
+        # 0.0 (default) keeps the pre-change binary alive/dead gate.
+        min_hp_fraction = 0.0
+        try:
+            custom_skill = self.GetCustomSkill(skill_id)
+            if custom_skill is not None:
+                min_hp_fraction = float(custom_skill.Conditions.MinSpiritHpFractionForRecast or 0.0)
+        except Exception:
+            min_hp_fraction = 0.0
+
         spirit_array = AgentArray.GetSpiritPetArray()
         spirit_array = AgentArray.Filter.ByDistance(spirit_array, Player.GetXY(), Range.Earshot.value)
         spirit_array = AgentArray.Filter.ByCondition(spirit_array, lambda agent_id: Agent.IsAlive(agent_id))
@@ -1062,6 +1074,8 @@ class BuildMgr:
 
             spirit_model_id = SpiritModelID(model_value)
             if SPIRIT_BUFF_MAP.get(spirit_model_id) == skill_id:
+                if min_hp_fraction > 0.0 and Agent.GetHealth(spirit_id) < min_hp_fraction:
+                    continue
                 return True
 
         return False

--- a/Py4GWCoreLib/Builds/Mesmer/Me_Any/Energy Surge.py
+++ b/Py4GWCoreLib/Builds/Mesmer/Me_Any/Energy Surge.py
@@ -26,6 +26,7 @@ class _EnergySurgeBarSnapshot:
     enemy_in_spellcast: bool = False
     enemy_casting: bool = False
     enemy_casting_spell: bool = False
+    enemy_casting_spell_or_chant: bool = False
     dead_ally_in_spellcast: int = 0
 
 
@@ -83,6 +84,7 @@ class Energy_Surge(BuildMgr):
         if snapshot.enemy_in_spellcast:
             snapshot.enemy_casting = bool(Routines.Targeting.GetEnemyCasting(Range.Spellcast.value))
             snapshot.enemy_casting_spell = bool(Routines.Targeting.GetEnemyCastingSpell(Range.Spellcast.value))
+            snapshot.enemy_casting_spell_or_chant = bool(Routines.Targeting.GetEnemyCastingSpellOrChant(Range.Spellcast.value))
 
         return snapshot
 
@@ -93,7 +95,7 @@ class Energy_Surge(BuildMgr):
 
         snapshot = self._get_bar_snapshot()
 
-        if snapshot.in_aggro and (yield from self.skills.Any.PvE.Air_of_Superiority()):
+        if (snapshot.in_aggro or self.IsCloseToAggro()) and (yield from self.skills.Any.PvE.Air_of_Superiority()):
             return True
 
         if (yield from self.skills.Any.NoAttribute.Breath_of_the_Great_Dwarf()):
@@ -112,13 +114,16 @@ class Energy_Surge(BuildMgr):
         if not snapshot.in_aggro:
             return False
 
+        if snapshot.enemy_casting_spell_or_chant and (yield from self.skills.Mesmer.InspirationMagic.Power_Drain(energy_threshold_pct=0.30)):
+            return True
+
         if snapshot.enemy_casting_spell and (yield from self.skills.Mesmer.DominationMagic.Mistrust()):
             return True
 
         if (yield from self.skills.Mesmer.DominationMagic.Shatter_Hex()):
             return True
 
-        if snapshot.enemy_casting_spell and (yield from self.skills.Mesmer.DominationMagic.Power_Drain()):
+        if snapshot.enemy_casting_spell_or_chant and (yield from self.skills.Mesmer.InspirationMagic.Power_Drain()):
             return True
 
         if snapshot.enemy_casting and (yield from self.skills.Any.PvE.Cry_of_Pain(allow_hex_fallback=False)):

--- a/Py4GWCoreLib/Builds/Mesmer/Me_Any/Ineptitude.py
+++ b/Py4GWCoreLib/Builds/Mesmer/Me_Any/Ineptitude.py
@@ -1,0 +1,101 @@
+from Py4GWCoreLib import Profession
+from Py4GWCoreLib import Routines
+from Py4GWCoreLib.Builds.Any.HeroAI import HeroAI as HeroAIBuild
+from Py4GWCoreLib import BuildMgr
+from Py4GWCoreLib.Skill import Skill
+from Py4GWCoreLib.Builds.Skills import SkillsTemplate
+
+Ineptitude_ID = Skill.GetID("Ineptitude")
+Wandering_Eye_ID = Skill.GetID("Wandering_Eye")
+Signet_of_Clumsiness_ID = Skill.GetID("Signet_of_Clumsiness")
+Arcane_Conundrum_ID = Skill.GetID("Arcane_Conundrum")
+Air_of_Superiority_ID = Skill.GetID("Air_of_Superiority")
+Ebon_Vanguard_Assassin_Support_ID = Skill.GetID("Ebon_Vanguard_Assassin_Support")
+Ebon_Battle_Standard_of_Wisdom_ID = Skill.GetID("Ebon_Battle_Standard_of_Wisdom")
+Power_Drain_ID = Skill.GetID("Power_Drain")
+Drain_Enchantment_ID = Skill.GetID("Drain_Enchantment")
+
+
+class Ineptitude(BuildMgr):
+    def __init__(self, match_only: bool = False):
+        super().__init__(
+            name="Ineptitude",
+            required_primary=Profession.Mesmer,
+            template_code="OQBDAawDSvAIg5ZkAAAAAAAAAA",
+            required_skills=[
+                Ineptitude_ID,
+                Wandering_Eye_ID,
+                Signet_of_Clumsiness_ID,
+            ],
+            optional_skills=[
+                Arcane_Conundrum_ID,
+                Air_of_Superiority_ID,
+                Ebon_Vanguard_Assassin_Support_ID,
+                Ebon_Battle_Standard_of_Wisdom_ID,
+                Power_Drain_ID,
+                Drain_Enchantment_ID,
+            ],
+        )
+        if match_only:
+            return
+
+        self.SetFallback("HeroAI", HeroAIBuild(standalone_fallback=True))
+        self.SetSkillCastingFn(self._run_local_skill_logic)
+        self.skills: SkillsTemplate = SkillsTemplate(self)
+
+    def _run_local_skill_logic(self):
+        if not Routines.Checks.Skills.CanCast():
+            yield from Routines.Yield.wait(100)
+            return False
+
+        if (
+            self.IsSkillEquipped(Air_of_Superiority_ID)
+            and (Routines.Checks.Agents.InAggro() or self.IsCloseToAggro())
+            and (yield from self.skills.Any.PvE.Air_of_Superiority())
+        ):
+            return True
+
+        if not Routines.Checks.Agents.InAggro():
+            return False
+
+        if (yield from self.skills.Mesmer.InspirationMagic.Power_Drain(energy_threshold_pct=0.30)):
+            return True
+
+        if (yield from self.skills.Mesmer.InspirationMagic.Drain_Enchantment(energy_threshold_pct=0.30)):
+            return True
+
+        if self.IsSkillEquipped(Ebon_Vanguard_Assassin_Support_ID) and (yield from self.skills.Any.PvE.Ebon_Vanguard_Assassin_Support()):
+            return True
+        
+        if (yield from self.skills.Mesmer.IllusionMagic.Ineptitude()):
+            return True
+
+        if (yield from self.skills.Mesmer.InspirationMagic.Power_Drain(energy_threshold_pct=0.50)):
+            return True
+
+        if (yield from self.skills.Mesmer.InspirationMagic.Drain_Enchantment(energy_threshold_pct=0.50)):
+            return True
+
+        if (yield from self.skills.Mesmer.IllusionMagic.Wandering_Eye()):
+            return True
+
+        if self.IsSkillEquipped(Arcane_Conundrum_ID) and (yield from self.skills.Mesmer.IllusionMagic.Arcane_Conundrum()):
+            return True
+
+        if (yield from self.skills.Mesmer.IllusionMagic.Signet_of_Clumsiness()):
+            return True
+
+        if (yield from self.skills.Mesmer.InspirationMagic.Power_Drain()):
+            return True
+
+        if (yield from self.skills.Mesmer.InspirationMagic.Drain_Enchantment()):
+            return True
+
+        if self.IsSkillEquipped(Ebon_Battle_Standard_of_Wisdom_ID) and (yield from self.CastSkillID(
+            skill_id=Ebon_Battle_Standard_of_Wisdom_ID,
+            log=False,
+            aftercast_delay=250,
+        )):
+            return True
+
+        yield

--- a/Py4GWCoreLib/Builds/Mesmer/Me_Mo/Holy Inept.py
+++ b/Py4GWCoreLib/Builds/Mesmer/Me_Mo/Holy Inept.py
@@ -48,16 +48,23 @@ class HolyInept(BuildMgr):
             yield from Routines.Yield.wait(100)
             return False
 
-        if self.IsSkillEquipped(Air_of_Superiority_ID) and (yield from self.skills.Any.PvE.Air_of_Superiority()):
+        if (
+            self.IsSkillEquipped(Air_of_Superiority_ID)
+            and (Routines.Checks.Agents.InAggro() or self.IsCloseToAggro())
+            and (yield from self.skills.Any.PvE.Air_of_Superiority())
+        ):
             return True
 
         if not Routines.Checks.Agents.InAggro():
             return False
 
+        if (yield from self.skills.Mesmer.InspirationMagic.Power_Drain(energy_threshold_pct=0.30)):
+            return True
+
         if self.IsSkillEquipped(Ebon_Vanguard_Assassin_Support_ID) and (yield from self.skills.Any.PvE.Ebon_Vanguard_Assassin_Support()):
             return True
 
-        if (yield from self.skills.Mesmer.DominationMagic.Power_Drain()):
+        if (yield from self.skills.Mesmer.InspirationMagic.Power_Drain()):
             return True
 
         if (yield from self.skills.Mesmer.IllusionMagic.Ineptitude()):

--- a/Py4GWCoreLib/Builds/Necromancer/N_Rt/Bip Resto Healer.py
+++ b/Py4GWCoreLib/Builds/Necromancer/N_Rt/Bip Resto Healer.py
@@ -58,7 +58,22 @@ class Bip_Resto(BuildMgr):
         if not Routines.Checks.Skills.CanCast():
             return False
 
-        if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul()):
+        # emergency: any ally at or below 40% HP preempts everything.
+        if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul(health_threshold=0.40)):
+            return True
+
+        # Signet of Lost Souls: emergency energy refill when caster < 30%.
+        if (yield from self.skills.Necromancer.SoulReaping.Signet_of_Lost_Souls(max_self_energy_pct=0.30)):
+            return True
+
+        # Recuperation 6+ allies below 75% HP OR 6+ allies degenning.
+        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
+            min_party_damaged_count=6,
+        )):
+            return True
+        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
+            min_degen_count=6,
+        )):
             return True
 
         if (yield from self.skills.Necromancer.BloodMagic.Blood_is_Power()):
@@ -73,6 +88,32 @@ class Bip_Resto(BuildMgr):
         if self.IsSkillEquipped(Spirit_Transfer_ID) and (yield from self.skills.Ritualist.RestorationMagic.Spirit_Transfer()):
             return True
 
+        # spirit-gated cleanse: blind on a martial (melee/ranger/paragon).
+        if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul(cleanse_blind_martial=True)):
+            return True
+
+        # spirit-gated cleanse: cripple on a melee ally.
+        if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul(cleanse_cripple_melee=True)):
+            return True
+
+        # Recuperation: 6+ allies below 75% HP OR 4+ allies degenning.
+        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
+            min_party_damaged_count=6,
+        )):
+            return True
+        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
+            min_degen_count=4,
+        )):
+            return True
+
+        # Signet of Lost Souls : energy refill when caster < 60%.
+        if (yield from self.skills.Necromancer.SoulReaping.Signet_of_Lost_Souls(max_self_energy_pct=0.60)):
+            return True
+
+        # damaged: any ally at or below 75% HP, before combat skills.
+        if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul(health_threshold=0.75)):
+            return True
+
         if not Routines.Checks.Agents.InAggro():
             return False
 
@@ -85,7 +126,22 @@ class Bip_Resto(BuildMgr):
         if self.IsSkillEquipped(Recovery_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recovery()):
             return True
 
-        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation()):
+        # Signet of Lost Souls: opportunistic refill, no caster energy gate.
+        if (yield from self.skills.Necromancer.SoulReaping.Signet_of_Lost_Souls()):
+            return True
+
+        # Recuperation: 6+ allies below 75% HP OR 2+ allies degenning.
+        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
+            min_party_damaged_count=6,
+        )):
+            return True
+        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
+            min_degen_count=2,
+        )):
+            return True
+
+        # preventive: any ally at or below 85% HP, after Recuperation.
+        if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul(health_threshold=0.85)):
             return True
 
         if self.IsSkillEquipped(Breath_of_the_Great_Dwarf_ID) and (yield from self.skills.Any.NoAttribute.Breath_of_the_Great_Dwarf()):
@@ -95,9 +151,6 @@ class Bip_Resto(BuildMgr):
             return True
 
         if self.IsSkillEquipped(Enfeebling_Blood_ID) and (yield from self.skills.Necromancer.Curses.Enfeebling_Blood()):
-            return True
-
-        if (yield from self.skills.Necromancer.SoulReaping.Signet_of_Lost_Souls()):
             return True
 
         if (yield from self.skills.Ritualist.RestorationMagic.Spirit_Light()):

--- a/Py4GWCoreLib/Builds/Necromancer/N_Rt/Xinraes Weapon Resto Healer.py
+++ b/Py4GWCoreLib/Builds/Necromancer/N_Rt/Xinraes Weapon Resto Healer.py
@@ -33,9 +33,8 @@ class Xinraes_Weapon_Resto_Healer(BuildMgr):
             template_code="OAhiYwh8AAAAAgqq0cyNMHnA",
             required_skills=[
                 Xinraes_Weapon_ID,
-                Life_ID,
                 Mend_Body_and_Soul_ID,
-                Spirit_Light_ID,
+                Signet_of_Lost_Souls_ID,
             ],
             optional_skills=[
                 Vital_Weapon_ID,
@@ -65,14 +64,25 @@ class Xinraes_Weapon_Resto_Healer(BuildMgr):
         if not Routines.Checks.Skills.CanCast():
             return False
 
+        # emergency: any ally at or below 40% HP preempts everything.
+        if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul(health_threshold=0.40)):
+            return True
+
+        # Recuperation 6+ allies below 75% HP OR 6+ allies degenning.
+        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
+            min_party_damaged_count=6,
+        )):
+            return True
+        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
+            min_degen_count=6,
+        )):
+            return True
+
         if (
             self.IsSkillEquipped(Air_of_Superiority_ID)
             and (Routines.Checks.Agents.InAggro() or self.IsCloseToAggro())
             and (yield from self.skills.Any.PvE.Air_of_Superiority())
         ):
-            return True
-
-        if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul()):
             return True
 
         if self.IsSkillEquipped(Wielders_Boon_ID) and (yield from self.skills.Ritualist.RestorationMagic.Wielders_Boon()):
@@ -84,9 +94,31 @@ class Xinraes_Weapon_Resto_Healer(BuildMgr):
         if self.IsSkillEquipped(Spirit_Transfer_ID) and (yield from self.skills.Ritualist.RestorationMagic.Spirit_Transfer()):
             return True
 
+        # spirit-gated cleanse: blind on a martial (melee/ranger/paragon).
+        if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul(cleanse_blind_martial=True)):
+            return True
+
+        # spirit-gated cleanse: cripple on a melee ally.
+        if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul(cleanse_cripple_melee=True)):
+            return True
+
+        # Recuperation 6+ allies below 75% HP OR 4+ allies degenning.
+        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
+            min_party_damaged_count=6,
+        )):
+            return True
+        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
+            min_degen_count=4,
+        )):
+            return True
+
+        # damaged: any ally at or below 75% HP, before combat skills.
+        if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul(health_threshold=0.75)):
+            return True
+
         if not Routines.Checks.Agents.InAggro():
             return False
-    
+
         if self.IsSkillEquipped(Ebon_Vanguard_Assassin_Support_ID) and (yield from self.skills.Any.PvE.Ebon_Vanguard_Assassin_Support()):
             return True
 
@@ -95,7 +127,7 @@ class Xinraes_Weapon_Resto_Healer(BuildMgr):
 
         if self.IsSkillEquipped(You_Are_All_Weaklings_ID) and (yield from self.skills.Any.NoAttribute.You_Are_All_Weaklings()):
             return True
-        
+
         if (yield from self.skills.Ritualist.RestorationMagic.Spirit_Light()):
             return True
 
@@ -114,7 +146,18 @@ class Xinraes_Weapon_Resto_Healer(BuildMgr):
         if self.IsSkillEquipped(Recovery_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recovery()):
             return True
 
-        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation()):
+        # Recuperation 6+ allies below 75% HP OR 2+ allies degenning.
+        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
+            min_party_damaged_count=6,
+        )):
+            return True
+        if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
+            min_degen_count=2,
+        )):
+            return True
+
+        # preventive: any ally at or below 85% HP, after Recuperation.
+        if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul(health_threshold=0.85)):
             return True
 
         if self.IsSkillEquipped(Breath_of_the_Great_Dwarf_ID) and (yield from self.skills.Any.NoAttribute.Breath_of_the_Great_Dwarf()):

--- a/Py4GWCoreLib/Builds/Necromancer/N_Rt/Xinraes Weapon Resto Healer.py
+++ b/Py4GWCoreLib/Builds/Necromancer/N_Rt/Xinraes Weapon Resto Healer.py
@@ -68,6 +68,10 @@ class Xinraes_Weapon_Resto_Healer(BuildMgr):
         if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul(health_threshold=0.40)):
             return True
 
+        # Signet of Lost Souls: emergency energy refill when caster < 30%.
+        if (yield from self.skills.Necromancer.SoulReaping.Signet_of_Lost_Souls(max_self_energy_pct=0.30)):
+            return True
+
         # Recuperation 6+ allies below 75% HP OR 6+ allies degenning.
         if self.IsSkillEquipped(Recuperation_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recuperation(
             min_party_damaged_count=6,
@@ -112,6 +116,10 @@ class Xinraes_Weapon_Resto_Healer(BuildMgr):
         )):
             return True
 
+        # Signet of Lost Souls: energy refill when caster < 60%.
+        if (yield from self.skills.Necromancer.SoulReaping.Signet_of_Lost_Souls(max_self_energy_pct=0.60)):
+            return True
+
         # damaged: any ally at or below 75% HP, before combat skills.
         if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul(health_threshold=0.75)):
             return True
@@ -134,9 +142,6 @@ class Xinraes_Weapon_Resto_Healer(BuildMgr):
         if self.IsSkillEquipped(Life_ID) and (yield from self.skills.Ritualist.RestorationMagic.Life()):
             return True
 
-        if (yield from self.skills.Necromancer.SoulReaping.Signet_of_Lost_Souls()):
-            return True
-
         if self.IsSkillEquipped(Weaken_Armor_ID) and (yield from self.skills.Necromancer.Curses.Weaken_Armor()):
             return True
 
@@ -144,6 +149,10 @@ class Xinraes_Weapon_Resto_Healer(BuildMgr):
             return True
 
         if self.IsSkillEquipped(Recovery_ID) and (yield from self.skills.Ritualist.RestorationMagic.Recovery()):
+            return True
+
+        # Signet of Lost Souls: opportunistic refill, no caster energy gate.
+        if (yield from self.skills.Necromancer.SoulReaping.Signet_of_Lost_Souls()):
             return True
 
         # Recuperation 6+ allies below 75% HP OR 2+ allies degenning.

--- a/Py4GWCoreLib/Builds/Necromancer/N_Rt/Xinraes Weapon Resto Healer.py
+++ b/Py4GWCoreLib/Builds/Necromancer/N_Rt/Xinraes Weapon Resto Healer.py
@@ -65,7 +65,11 @@ class Xinraes_Weapon_Resto_Healer(BuildMgr):
         if not Routines.Checks.Skills.CanCast():
             return False
 
-        if self.IsSkillEquipped(Air_of_Superiority_ID) and (yield from self.skills.Any.PvE.Air_of_Superiority()):
+        if (
+            self.IsSkillEquipped(Air_of_Superiority_ID)
+            and (Routines.Checks.Agents.InAggro() or self.IsCloseToAggro())
+            and (yield from self.skills.Any.PvE.Air_of_Superiority())
+        ):
             return True
 
         if (yield from self.skills.Ritualist.RestorationMagic.Mend_Body_and_Soul()):

--- a/Py4GWCoreLib/Builds/Ranger/R_A/Tao_Dagger_Spam.py
+++ b/Py4GWCoreLib/Builds/Ranger/R_A/Tao_Dagger_Spam.py
@@ -77,7 +77,11 @@ class Tao_Dagger_Spam(BuildMgr):
         if self.IsSkillEquipped(Breath_of_the_Great_Dwarf_ID) and (yield from self.skills.Any.NoAttribute.Breath_of_the_Great_Dwarf()):
             return True
             
-        if self.IsSkillEquipped(Air_of_Superiority_ID) and (yield from self.skills.Any.PvE.Air_of_Superiority()):
+        if (
+            self.IsSkillEquipped(Air_of_Superiority_ID)
+            and (Routines.Checks.Agents.InAggro() or self.IsCloseToAggro())
+            and (yield from self.skills.Any.PvE.Air_of_Superiority())
+        ):
             return
 
         if not Routines.Checks.Agents.InAggro():

--- a/Py4GWCoreLib/Builds/Skills/mesmer/DominationMagic.py
+++ b/Py4GWCoreLib/Builds/Skills/mesmer/DominationMagic.py
@@ -228,27 +228,6 @@ class DominationMagic:
         ))
     #endregion
 
-    #region P
-    def Power_Drain(self) -> BuildCoroutine:
-        from Py4GWCoreLib import Routines, Range
-
-        power_drain_id: int = Skill.GetID("Power_Drain")
-
-        if not self.build.IsSkillEquipped(power_drain_id):
-            return False
-
-        target_agent_id: int = Routines.Targeting.GetEnemyCastingSpell(Range.Spellcast.value)
-        if not target_agent_id:
-            return False
-
-        return (yield from self.build.CastSkillIDAndRestoreTarget(
-            skill_id=power_drain_id,
-            target_agent_id=target_agent_id,
-            log=False,
-            aftercast_delay=250,
-        ))
-    #endregion
-
     #region S
     def Shatter_Hex(self) -> BuildCoroutine:
         shatter_hex_id: int = Skill.GetID("Shatter_Hex")

--- a/Py4GWCoreLib/Builds/Skills/mesmer/IllusionMagic.py
+++ b/Py4GWCoreLib/Builds/Skills/mesmer/IllusionMagic.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from HeroAI.targeting import TargetCasterClusterEnemy, TargetMeleeOrMartialClusterEnemy
 from Py4GWCoreLib.BuildMgr import BuildCoroutine
 from Py4GWCoreLib.Skill import Skill
-from Py4GWCoreLib import Agent, GLOBAL_CACHE, Player, Range, Routines
-from .._targeting import EnemyClusterTargetingMixin
 
 if TYPE_CHECKING:
     from Py4GWCoreLib.BuildMgr import BuildMgr
@@ -13,36 +12,9 @@ if TYPE_CHECKING:
 __all__ = ["IllusionMagic"]
 
 
-class IllusionMagic(EnemyClusterTargetingMixin):
+class IllusionMagic:
     def __init__(self, build: BuildMgr) -> None:
         self.build: BuildMgr = build
-
-    def _pick_illusion_target(self, skill_id: int) -> int:
-        enemy_array = self._get_enemy_array(Range.Spellcast.value)
-        if not enemy_array:
-            return 0
-
-        aoe_range = GLOBAL_CACHE.Skill.Data.GetAoERange(skill_id) or Range.Nearby.value
-        attacking_targets = [agent_id for agent_id in enemy_array if Agent.IsAttacking(agent_id)]
-        target_agent_id = self._pick_best_target(attacking_targets, aoe_range)
-
-        if not target_agent_id:
-            current_target_id = Player.GetTargetID()
-            best_enemy_target_id = self._pick_best_target(enemy_array, aoe_range)
-            if (
-                current_target_id in enemy_array
-                and Agent.IsValid(current_target_id)
-                and not Agent.IsDead(current_target_id)
-            ):
-                current_target_score = self._get_cluster_score(current_target_id, aoe_range)
-                best_enemy_score = self._get_cluster_score(best_enemy_target_id, aoe_range)
-                if current_target_score >= best_enemy_score:
-                    target_agent_id = current_target_id
-
-        if not target_agent_id:
-            target_agent_id = self._pick_best_target(enemy_array, aoe_range)
-
-        return target_agent_id
 
     #region A
     def Arcane_Conundrum(self) -> BuildCoroutine:
@@ -51,7 +23,7 @@ class IllusionMagic(EnemyClusterTargetingMixin):
         if not self.build.IsSkillEquipped(arcane_conundrum_id):
             return False
 
-        target_agent_id: int = Routines.Agents.GetNearestEnemyCaster(Range.Spellcast.value)
+        target_agent_id = TargetCasterClusterEnemy(arcane_conundrum_id)
         if not target_agent_id:
             return False
 
@@ -68,7 +40,8 @@ class IllusionMagic(EnemyClusterTargetingMixin):
         ineptitude_id: int = Skill.GetID("Ineptitude")
         if not self.build.IsSkillEquipped(ineptitude_id):
             return False
-        target_agent_id = self._pick_illusion_target(ineptitude_id)
+
+        target_agent_id = TargetMeleeOrMartialClusterEnemy(ineptitude_id)
         if not target_agent_id:
             return False
 
@@ -85,7 +58,14 @@ class IllusionMagic(EnemyClusterTargetingMixin):
         signet_of_clumsiness_id: int = Skill.GetID("Signet_of_Clumsiness")
         if not self.build.IsSkillEquipped(signet_of_clumsiness_id):
             return False
-        target_agent_id = self._pick_illusion_target(signet_of_clumsiness_id)
+
+        # Signet of Clumsiness only interrupts and deals damage when the
+        # target is attacking, so require an attacking enemy in both the
+        # primary and fallback branches; if no attacker exists, skip the cast.
+        target_agent_id = TargetMeleeOrMartialClusterEnemy(
+            signet_of_clumsiness_id,
+            require_attacking=True,
+        )
         if not target_agent_id:
             return False
 
@@ -102,7 +82,8 @@ class IllusionMagic(EnemyClusterTargetingMixin):
         wandering_eye_id: int = Skill.GetID("Wandering_Eye")
         if not self.build.IsSkillEquipped(wandering_eye_id):
             return False
-        target_agent_id = self._pick_illusion_target(wandering_eye_id)
+
+        target_agent_id = TargetMeleeOrMartialClusterEnemy(wandering_eye_id)
         if not target_agent_id:
             return False
 

--- a/Py4GWCoreLib/Builds/Skills/mesmer/InspirationMagic.py
+++ b/Py4GWCoreLib/Builds/Skills/mesmer/InspirationMagic.py
@@ -35,6 +35,62 @@ class InspirationMagic:
             aftercast_delay=250,
         ))
 
+    def Drain_Enchantment(
+        self,
+        *,
+        energy_threshold_pct: float = 0.80,
+        energy_threshold_abs: float | None = None,
+    ) -> BuildCoroutine:
+        from Py4GWCoreLib import Agent, AgentArray, Player, Range, Routines, Utils
+
+        drain_enchantment_id: int = Skill.GetID("Drain_Enchantment")
+
+        if not self.build.IsSkillEquipped(drain_enchantment_id):
+            return False
+
+        # Drain Enchantment refunds energy and health on a successful strip,
+        # so gate on the player's current energy the same way Power_Drain
+        # does. Absolute threshold (when set) wins over the percentage.
+        player_id = Player.GetAgentID()
+        if energy_threshold_abs is not None:
+            current_energy_abs = Agent.GetEnergy(player_id) * Agent.GetMaxEnergy(player_id)
+            if current_energy_abs > energy_threshold_abs:
+                return False
+        elif Agent.GetEnergy(player_id) > energy_threshold_pct:
+            return False
+
+        player_pos = Player.GetXY()
+        enemy_array = Routines.Agents.GetFilteredEnemyArray(
+            player_pos[0], player_pos[1], Range.Spellcast.value
+        )
+        enchanted_enemies = AgentArray.Filter.ByCondition(
+            enemy_array,
+            lambda agent_id: (
+                Agent.IsValid(agent_id)
+                and not Agent.IsDead(agent_id)
+                and Agent.IsEnchanted(agent_id)
+            ),
+        )
+        if not enchanted_enemies:
+            return False
+
+        # Rank lowest-HP enchanted enemy first, break ties by proximity so a
+        # close, low-HP strip wins over a far one with the same HP.
+        target_agent_id = min(
+            enchanted_enemies,
+            key=lambda agent_id: (
+                Agent.GetHealth(agent_id),
+                Utils.Distance(player_pos, Agent.GetXY(agent_id)),
+            ),
+        )
+
+        return (yield from self.build.CastSkillIDAndRestoreTarget(
+            skill_id=drain_enchantment_id,
+            target_agent_id=target_agent_id,
+            log=False,
+            aftercast_delay=250,
+        ))
+
     def Power_Drain(
         self,
         *,

--- a/Py4GWCoreLib/Builds/Skills/mesmer/InspirationMagic.py
+++ b/Py4GWCoreLib/Builds/Skills/mesmer/InspirationMagic.py
@@ -34,3 +34,38 @@ class InspirationMagic:
             log=False,
             aftercast_delay=250,
         ))
+
+    def Power_Drain(
+        self,
+        *,
+        energy_threshold_pct: float = 0.70,
+        energy_threshold_abs: float | None = None,
+    ) -> BuildCoroutine:
+        from Py4GWCoreLib import Agent, Player, Range, Routines
+
+        power_drain_id: int = Skill.GetID("Power_Drain")
+
+        if not self.build.IsSkillEquipped(power_drain_id):
+            return False
+
+        # Power Drain exists to refill energy. Skip when the player does not
+        # need it. Absolute threshold (when set) wins over the percentage
+        # threshold so critical-tier call sites can express a flat floor.
+        player_id = Player.GetAgentID()
+        if energy_threshold_abs is not None:
+            current_energy_abs = Agent.GetEnergy(player_id) * Agent.GetMaxEnergy(player_id)
+            if current_energy_abs > energy_threshold_abs:
+                return False
+        elif Agent.GetEnergy(player_id) > energy_threshold_pct:
+            return False
+
+        target_agent_id: int = Routines.Targeting.GetEnemyCastingSpellOrChant(Range.Spellcast.value)
+        if not target_agent_id:
+            return False
+
+        return (yield from self.build.CastSkillIDAndRestoreTarget(
+            skill_id=power_drain_id,
+            target_agent_id=target_agent_id,
+            log=False,
+            aftercast_delay=250,
+        ))

--- a/Py4GWCoreLib/Builds/Skills/necromancer/BloodMagic.py
+++ b/Py4GWCoreLib/Builds/Skills/necromancer/BloodMagic.py
@@ -30,7 +30,33 @@ class BloodMagic:
             return self.bip_throttle.IsStopped() or self.bip_throttle.IsExpired()
 
         def _can_safely_cast_bip() -> bool:
-            return Agent.GetHealth(Player.GetAgentID()) > blood_is_power.Conditions.SacrificeHealth
+            # Refuse if the caster's HP after the BiP sacrifice would land at or
+            # below the percent-of-max floor or the absolute-HP floor. Mirrors the
+            # post-sacrifice safety check in HeroAI/combat.py so the build path
+            # honors the same floors as the HeroAI fallback.
+            player_id = Player.GetAgentID()
+            conditions = blood_is_power.Conditions
+
+            current_hp_fraction = float(Agent.GetHealth(player_id))
+            sacrifice_floor = float(conditions.SacrificeHealth or 0.0)
+            if current_hp_fraction <= sacrifice_floor:
+                return False
+
+            sacrifice_pct = float(conditions.SacrificePercent or 0.0)
+            min_after_pct = float(conditions.MinHealthAfterSacrificePercent or 0.0)
+            min_after_abs = int(conditions.MinHealthAfterSacrificeAbsolute or 0)
+            if sacrifice_pct > 0 and (min_after_pct > 0 or min_after_abs > 0):
+                max_hp = Agent.GetMaxHealth(player_id)
+                if max_hp <= 0:
+                    return False
+                sacrifice_amount = max_hp * sacrifice_pct
+                hp_after_sacrifice = (current_hp_fraction * max_hp) - sacrifice_amount
+                if min_after_abs > 0 and hp_after_sacrifice <= min_after_abs:
+                    return False
+                if min_after_pct > 0 and (hp_after_sacrifice / max_hp) <= min_after_pct:
+                    return False
+
+            return True
 
         if not self.build.IsSkillEquipped(blood_is_power_id):
             return False

--- a/Py4GWCoreLib/Builds/Skills/necromancer/SoulReaping.py
+++ b/Py4GWCoreLib/Builds/Skills/necromancer/SoulReaping.py
@@ -20,43 +20,42 @@ class SoulReaping:
         self.build: BuildMgr = build
 
     #region S
-    def Signet_of_Lost_Souls(self) -> BuildCoroutine:
+    def Signet_of_Lost_Souls(
+        self,
+        *,
+        max_self_energy_pct: float | None = None,
+    ) -> BuildCoroutine:
+        from Py4GWCoreLib import Utils
+
         signet_of_lost_souls_id: int = Skill.GetID("Signet_of_Lost_Souls")
-        signet_of_lost_souls: CustomSkill = self.build.GetCustomSkill(signet_of_lost_souls_id)
-
-        def _should_cast_signet_of_lost_souls() -> bool:
-            player_agent_id = Player.GetAgentID()
-            return (
-                Agent.GetHealth(player_agent_id) < signet_of_lost_souls.Conditions.LessLife
-                or Agent.GetEnergy(player_agent_id) < signet_of_lost_souls.Conditions.LessEnergy
-            )
-
-        def _resolve_signet_of_lost_souls_target() -> int:
-            enemy_array = AgentArray.GetEnemyArray()
-            enemy_array = AgentArray.Filter.ByDistance(
-                enemy_array,
-                Player.GetXY(),
-                Range.Spellcast.value,
-            )
-            enemy_array = AgentArray.Filter.ByCondition(
-                enemy_array,
-                lambda agent_id: Agent.IsAlive(agent_id),
-            )
-            enemy_array = AgentArray.Filter.ByCondition(
-                enemy_array,
-                lambda agent_id: Agent.GetHealth(agent_id) < 0.5,
-            )
-            enemy_array = AgentArray.Sort.ByHealth(enemy_array)
-            return enemy_array[0] if enemy_array else 0
 
         if not self.build.IsSkillEquipped(signet_of_lost_souls_id):
             return False
-        if not _should_cast_signet_of_lost_souls():
+
+        # Optional caster-energy gate. When set, fire only if the caster's energy
+        # fraction is strictly below the threshold. When None (default) there is
+        # no caster-side gate - the signet is free HP/energy whenever an eligible
+        # target exists, so the caller's chain position bounds when it fires.
+        if max_self_energy_pct is not None:
+            if Agent.GetEnergy(Player.GetAgentID()) >= max_self_energy_pct:
+                return False
+
+        # Target filter: enemy within Spellcast range, alive, below the signet's
+        # 50% trigger threshold. Sort closest-first with lower HP as tiebreak so
+        # the target is both reliable (unlikely to slip out of range during the
+        # 1/4s cast) and likely to still be <50% when the signet resolves.
+        player_pos = Player.GetXY()
+        enemy_array = AgentArray.GetEnemyArray()
+        enemy_array = AgentArray.Filter.ByDistance(enemy_array, player_pos, Range.Spellcast.value)
+        enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Agent.IsAlive(agent_id))
+        enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Agent.GetHealth(agent_id) < 0.5)
+        if not enemy_array:
             return False
 
-        target_agent_id = _resolve_signet_of_lost_souls_target()
-        if not target_agent_id:
-            return False
+        target_agent_id = sorted(
+            enemy_array,
+            key=lambda aid: (Utils.Distance(player_pos, Agent.GetXY(aid)), Agent.GetHealth(aid)),
+        )[0]
 
         return (yield from self.build.CastSkillID(
             skill_id=signet_of_lost_souls_id,

--- a/Py4GWCoreLib/Builds/Skills/ritualist/RestorationMagic.py
+++ b/Py4GWCoreLib/Builds/Skills/ritualist/RestorationMagic.py
@@ -160,60 +160,16 @@ class RestorationMagic:
 
     #region X
     def Xinraes_Weapon(self) -> BuildCoroutine:
-        from Py4GWCoreLib import AgentArray, GLOBAL_CACHE, Utils
-        from HeroAI.targeting import GetAllAlliesArray
+        from HeroAI.targeting import TargetAllyWeaponSpell
 
         xinraes_weapon_id: int = Skill.GetID("Xinraes_Weapon")
-        refresh_window_ms = 1000
 
         if not self.build.IsSkillEquipped(xinraes_weapon_id):
             return False
 
-        # Eligible = no weapon spell, or our Xinrae's is about to expire.
-        # A different weapon spell on the ally blocks the cast so we never
-        # overwrite Wielder's Boon / Vital Weapon / etc.
-        def _is_refresh_eligible(agent_id: int) -> bool:
-            if not Agent.IsWeaponSpelled(agent_id):
-                return True
-            if not Routines.Checks.Agents.HasEffect(agent_id, xinraes_weapon_id):
-                return False
-            remaining_ms = GLOBAL_CACHE.Effects.GetEffectTimeRemaining(agent_id, xinraes_weapon_id)
-            return remaining_ms <= refresh_window_ms
-
-        ally_array = GetAllAlliesArray(Range.Spellcast.value) or []
-        candidates = [
-            agent_id for agent_id in ally_array
-            if Agent.IsValid(agent_id)
-            and Routines.Checks.Agents.IsAlive(agent_id)
-            and _is_refresh_eligible(agent_id)
-        ]
-        if not candidates:
+        target_agent_id = TargetAllyWeaponSpell(xinraes_weapon_id, Range.Spellcast.value)
+        if not target_agent_id:
             return False
-
-        # Xinrae's triggers on the ally's next incoming hit, so the best target
-        # is the one most likely to take damage soon: most enemies within
-        # Earshot first, then lowest HP, then closest to the caster.
-        def _enemies_near(agent_id: int) -> int:
-            ally_x, ally_y = Agent.GetXY(agent_id)
-            nearby = Routines.Agents.GetFilteredEnemyArray(ally_x, ally_y, Range.Earshot.value)
-            nearby = AgentArray.Filter.ByCondition(
-                nearby,
-                lambda enemy_id: Agent.IsValid(enemy_id) and not Agent.IsDead(enemy_id),
-            )
-            return len(nearby)
-
-        player_pos = Player.GetXY()
-        scored = [
-            (
-                -_enemies_near(agent_id),
-                Agent.GetHealth(agent_id),
-                Utils.Distance(player_pos, Agent.GetXY(agent_id)),
-                agent_id,
-            )
-            for agent_id in candidates
-        ]
-        scored.sort()
-        target_agent_id = scored[0][3]
 
         return (yield from self.build.CastSkillIDAndRestoreTarget(
             xinraes_weapon_id,

--- a/Py4GWCoreLib/Builds/Skills/ritualist/RestorationMagic.py
+++ b/Py4GWCoreLib/Builds/Skills/ritualist/RestorationMagic.py
@@ -46,30 +46,77 @@ class RestorationMagic:
     #endregion
 
     #region M
-    def Mend_Body_and_Soul(self) -> BuildCoroutine:
+    def Mend_Body_and_Soul(
+        self,
+        *,
+        health_threshold: float | None = None,
+        cleanse_blind_martial: bool = False,
+        cleanse_cripple_melee: bool = False,
+    ) -> BuildCoroutine:
+        from HeroAI.targeting import GetAllAlliesArray
+
         mend_body_and_soul_id: int = Skill.GetID("Mend_Body_and_Soul")
         mend_body_and_soul: CustomSkill = self.build.GetCustomSkill(mend_body_and_soul_id)
-        health_threshold: float = max(0.0, min(1.0, float(mend_body_and_soul.Conditions.LessLife or 0.70)))
-
-        def _resolve_mend_body_and_soul_target() -> int:
-            variants = [None]
-            if self._has_spirit_in_earshot():
-                variants = [
-                    lambda custom_skill: setattr(custom_skill.Conditions, "HasCondition", True),
-                    None,
-                ]
-
-            return self.build.ResolvePreferredAllyTarget(
-                mend_body_and_soul_id,
-                mend_body_and_soul,
-                variants=variants,
-                validator=lambda agent_id: Agent.IsAlive(agent_id) and Agent.GetHealth(agent_id) < health_threshold,
-            )
 
         if not self.build.IsSkillEquipped(mend_body_and_soul_id):
             return False
 
-        target_agent_id = _resolve_mend_body_and_soul_target()
+        # Cleanse-oriented tiers: MBaS removes one condition per cast only when a
+        # spirit is in earshot, so gate the tier on the spirit + profession-specific
+        # carriers of the targeted condition.
+        if cleanse_blind_martial or cleanse_cripple_melee:
+            if not self._has_spirit_in_earshot():
+                return False
+
+            if cleanse_blind_martial:
+                blind_skill_id: int = Skill.GetID("Blind")
+                profession_predicate = lambda aid: Routines.Checks.Agents.IsMartial(aid)
+                condition_predicate = lambda aid: Routines.Checks.Agents.HasEffect(aid, blind_skill_id)
+            else:
+                profession_predicate = lambda aid: Routines.Checks.Agents.IsMelee(aid)
+                condition_predicate = lambda aid: Agent.IsCrippled(aid)
+
+            ally_array = GetAllAlliesArray(Range.Spellcast.value) or []
+            candidates = [
+                agent_id for agent_id in ally_array
+                if Agent.IsValid(agent_id)
+                and Agent.IsAlive(agent_id)
+                and profession_predicate(agent_id)
+                and condition_predicate(agent_id)
+            ]
+            if not candidates:
+                return False
+
+            candidates.sort(key=lambda aid: Agent.GetHealth(aid))
+            target_agent_id = candidates[0]
+        else:
+            # HP-threshold tier: caller overrides the metadata's LessLife when it
+            # wants a specific tier (emergency, damaged, preventive) rather than
+            # the bar-wide default. When None, fall back to metadata (0.70 default).
+            threshold: float = (
+                health_threshold
+                if health_threshold is not None
+                else float(mend_body_and_soul.Conditions.LessLife or 0.70)
+            )
+            threshold = max(0.0, min(1.0, threshold))
+
+            def _resolve_mend_body_and_soul_target() -> int:
+                variants: list = [None]
+                if self._has_spirit_in_earshot():
+                    variants = [
+                        lambda custom_skill: setattr(custom_skill.Conditions, "HasCondition", True),
+                        None,
+                    ]
+
+                return self.build.ResolvePreferredAllyTarget(
+                    mend_body_and_soul_id,
+                    mend_body_and_soul,
+                    variants=variants,
+                    validator=lambda aid: Agent.IsAlive(aid) and Agent.GetHealth(aid) < threshold,
+                )
+
+            target_agent_id = _resolve_mend_body_and_soul_target()
+
         if not target_agent_id:
             return False
 
@@ -113,21 +160,60 @@ class RestorationMagic:
 
     #region X
     def Xinraes_Weapon(self) -> BuildCoroutine:
-        xinraes_weapon_id: int = Skill.GetID("Xinraes_Weapon")
-        xinraes_weapon: CustomSkill = self.build.GetCustomSkill(xinraes_weapon_id)
+        from Py4GWCoreLib import AgentArray, GLOBAL_CACHE, Utils
+        from HeroAI.targeting import GetAllAlliesArray
 
-        def _resolve_xinraes_weapon_target() -> int:
-            return self.build.ResolveAllyTarget(
-                xinraes_weapon_id,
-                xinraes_weapon,
-            )
+        xinraes_weapon_id: int = Skill.GetID("Xinraes_Weapon")
+        refresh_window_ms = 1000
 
         if not self.build.IsSkillEquipped(xinraes_weapon_id):
             return False
 
-        target_agent_id = _resolve_xinraes_weapon_target()
-        if not target_agent_id:
+        # Eligible = no weapon spell, or our Xinrae's is about to expire.
+        # A different weapon spell on the ally blocks the cast so we never
+        # overwrite Wielder's Boon / Vital Weapon / etc.
+        def _is_refresh_eligible(agent_id: int) -> bool:
+            if not Agent.IsWeaponSpelled(agent_id):
+                return True
+            if not Routines.Checks.Agents.HasEffect(agent_id, xinraes_weapon_id):
+                return False
+            remaining_ms = GLOBAL_CACHE.Effects.GetEffectTimeRemaining(agent_id, xinraes_weapon_id)
+            return remaining_ms <= refresh_window_ms
+
+        ally_array = GetAllAlliesArray(Range.Spellcast.value) or []
+        candidates = [
+            agent_id for agent_id in ally_array
+            if Agent.IsValid(agent_id)
+            and Routines.Checks.Agents.IsAlive(agent_id)
+            and _is_refresh_eligible(agent_id)
+        ]
+        if not candidates:
             return False
+
+        # Xinrae's triggers on the ally's next incoming hit, so the best target
+        # is the one most likely to take damage soon: most enemies within
+        # Earshot first, then lowest HP, then closest to the caster.
+        def _enemies_near(agent_id: int) -> int:
+            ally_x, ally_y = Agent.GetXY(agent_id)
+            nearby = Routines.Agents.GetFilteredEnemyArray(ally_x, ally_y, Range.Earshot.value)
+            nearby = AgentArray.Filter.ByCondition(
+                nearby,
+                lambda enemy_id: Agent.IsValid(enemy_id) and not Agent.IsDead(enemy_id),
+            )
+            return len(nearby)
+
+        player_pos = Player.GetXY()
+        scored = [
+            (
+                -_enemies_near(agent_id),
+                Agent.GetHealth(agent_id),
+                Utils.Distance(player_pos, Agent.GetXY(agent_id)),
+                agent_id,
+            )
+            for agent_id in candidates
+        ]
+        scored.sort()
+        target_agent_id = scored[0][3]
 
         return (yield from self.build.CastSkillIDAndRestoreTarget(
             xinraes_weapon_id,
@@ -148,17 +234,102 @@ class RestorationMagic:
             aftercast_delay=250,
         ))
 
-    def Recuperation(self) -> BuildCoroutine:
+    def Recuperation(
+        self,
+        *,
+        min_degen_count: int = 0,
+        min_party_damaged_count: int = 0,
+    ) -> BuildCoroutine:
         recuperation_id: int = Skill.GetID("Recuperation")
 
         if not self.build.IsSkillEquipped(recuperation_id):
             return False
+
+        # State gate: only fire during active combat or the approach phase - never
+        # during pure downtime.
+        if not (Routines.Checks.Agents.InAggro() or self.build.IsCloseToAggro()):
+            return False
+
+        # Independent situational gates. Callers that want OR semantics across
+        # gates should call Recuperation twice (once per gate) so the "OR" is
+        # explicit in the priority chain.
+        #   `min_degen_count`         - N allies in Spirit range suffering any
+        #                               health-degen source (poison / bleeding /
+        #                               burning / degen hex).
+        #   `min_party_damaged_count` - N allies in Spirit range below 75% HP.
+        # HP-aware recast (spirit at < 20% HP) is enforced by
+        # BuildMgr.SpiritBuffExists via the Recuperation custom-skill metadata
+        # (Conditions.MinSpiritHpFractionForRecast = 0.20).
+        if min_degen_count > 0:
+            if self._count_allies_suffering_degen() < min_degen_count:
+                return False
+
+        if min_party_damaged_count > 0:
+            if not self._is_party_damaged(
+                within_range=Range.Spirit.value,
+                min_allies_count=min_party_damaged_count,
+                less_health_than_percent=0.75,
+            ):
+                return False
 
         return (yield from self.build.CastSpiritSkillID(
             skill_id=recuperation_id,
             log=False,
             aftercast_delay=250,
         ))
+
+    @staticmethod
+    def _is_suffering_degen(agent_id: int, burning_skill_id: int) -> bool:
+        """Check if an ally has any health-degen condition: poison (-4),
+        bleeding (-3), burning (-7), or a degen hex."""
+        from Py4GWCoreLib.Effect import Effects
+        if Agent.IsPoisoned(agent_id):
+            return True
+        if Agent.IsBleeding(agent_id):
+            return True
+        if Agent.IsDegenHexed(agent_id):
+            return True
+        if Effects.HasEffect(agent_id, burning_skill_id):
+            return True
+        return False
+
+    def _count_allies_suffering_degen(self) -> int:
+        """Count party allies in Spirit range suffering any health-degen source."""
+        from Py4GWCoreLib import AgentArray, GLOBAL_CACHE
+
+        ally_ids = AgentArray.GetAllyArray()
+        ally_ids = AgentArray.Filter.ByDistance(ally_ids, Player.GetXY(), Range.Spirit.value)
+        ally_ids = AgentArray.Filter.ByCondition(ally_ids, lambda aid: Agent.IsAlive(aid))
+
+        burning_skill_id = GLOBAL_CACHE.Skill.GetID("Burning")
+        count = 0
+        for aid in ally_ids:
+            if self._is_suffering_degen(aid, burning_skill_id):
+                count += 1
+        return count
+
+    @staticmethod
+    def _is_party_damaged(
+        within_range: float,
+        min_allies_count: int,
+        less_health_than_percent: float,
+    ) -> bool:
+        """Return True when at least `min_allies_count` allies within range are
+        alive and currently below `less_health_than_percent` HP (0.0-1.0). Short
+        -circuits as soon as the threshold is reached."""
+        from Py4GWCoreLib import AgentArray
+
+        ally_ids = AgentArray.GetAllyArray()
+        ally_ids = AgentArray.Filter.ByDistance(ally_ids, Player.GetXY(), within_range)
+        ally_ids = AgentArray.Filter.ByCondition(ally_ids, lambda aid: Agent.IsAlive(aid))
+
+        count = 0
+        for aid in ally_ids:
+            if Agent.GetHealth(aid) < less_health_than_percent:
+                count += 1
+                if count >= min_allies_count:
+                    return True
+        return False
     #endregion
 
     #region S

--- a/Py4GWCoreLib/routines_src/Targeting.py
+++ b/Py4GWCoreLib/routines_src/Targeting.py
@@ -283,10 +283,32 @@ class Targeting:
         return Utils.GetFirstFromArray(enemy_array)
 
     @staticmethod
-    def GetEnemyInjured(max_distance=4500.0, aggressive_only = False): 
-        from ..Py4GWcorelib import Utils 
-        from ..AgentArray import AgentArray 
-        from ..GlobalCache import GLOBAL_CACHE 
+    def GetEnemyCastingSpellOrChant(max_distance=4500.0, aggressive_only=False):
+        from ..Py4GWcorelib import Utils
+        from ..AgentArray import AgentArray
+        from ..GlobalCache import GLOBAL_CACHE
+        from .Agents import Agents
+        from ..Agent import Agent
+        def _filter_spells_or_chants(enemy_array):
+            result_array = []
+            for enemy_id in enemy_array:
+                casting_skill_id = Agent.GetCastingSkillID(enemy_id)
+                if GLOBAL_CACHE.Skill.Flags.IsSpell(casting_skill_id) or GLOBAL_CACHE.Skill.Flags.IsChant(casting_skill_id):
+                    result_array.append(enemy_id)
+            return result_array
+
+        player_pos = Player.GetXY()
+        enemy_array = Agents.GetFilteredEnemyArray(player_pos[0], player_pos[1], max_distance, aggressive_only)
+        enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: Agent.IsCasting(agent_id))
+        enemy_array = _filter_spells_or_chants(enemy_array)
+        enemy_array = AgentArray.Sort.ByDistance(enemy_array, player_pos)
+        return Utils.GetFirstFromArray(enemy_array)
+
+    @staticmethod
+    def GetEnemyInjured(max_distance=4500.0, aggressive_only = False):
+        from ..Py4GWcorelib import Utils
+        from ..AgentArray import AgentArray
+        from ..GlobalCache import GLOBAL_CACHE
         from .Agents import Agents 
         from ..Agent import Agent
         player_pos = Player.GetXY() 


### PR DESCRIPTION
**Summary**

- A new targeting helper to select enemies currently casting spells OR chants.
- Update builds (Energy Surge, Holy Inept) to detect casting-or-chant and call the new Power_Drain logic;
-  Introduce a new cast condition LessSelfEnergyPercentage and wire its check into CombatClass so interrupts like energy-refund skills are skipped when the caster has sufficient energy.
- Updated Necromancer (Xinraes Weapon Resto Healer) and Ranger (Tao_Dagger_Spam) builds to require Routines.Checks.Agents.InAggro() or self.IsCloseToAggro() in addition to the existing skill checks.
- Add HP-aware spirit recast metadata and update Ritualist healing logic. CastConditions.MinSpiritHpFractionForRecast (default 0.0) and set it to 0.20 for the relevant Ritualist skill so spirits can be treated as absent and preemptively refreshed when their HP falls below the fraction.
- Expand RestorationMagic.Mend_Body_and_Soul to accept health_threshold override and two cleanse modes (blind on martial, cripple on melee). Target resolution now respects spirit presence for cleanse tiers and uses metadata/default thresholds for HP tiers.
- Improve Xinraes_Weapon targeting: prefer allies without a weapon spell or whose Xinrae's is expiring, score candidates by nearby enemies, HP, and distance to pick the best target.
-   Update a Necromancer build (Xinrae's weapon resto healer) to use the new APIs and adjust priority/order/thresholds for Mend_Body_and_Soul and Recuperation calls and some skill list changes.
- Extend Recuperation with min_degen_count and min_party_damaged_count gates, require combat/approach state, and add helper methods to count allies suffering degen and party damage checks. Document that Recuperation uses the MinSpiritHpFractionForRecast metadata for HP-aware recast.