### PR TITLE
Items, mods, crafting, trading & more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ cython_debug/
 
 # macOS system files
 .DS_Store
+/Sources/frenkeyLib/Scripts/output

--- a/Py4GWCoreLib/GlobalCache/MerchantCache.py
+++ b/Py4GWCoreLib/GlobalCache/MerchantCache.py
@@ -68,7 +68,7 @@ class TradingCache:
         def __init__(self, parent):
             self._parent = parent
             
-        def ExghangeItem(self, item_id, cost =0, item_list=[], item_quantities=[]):
+        def ExchangeItem(self, item_id, cost =0, item_list=[], item_quantities=[]):
             self._parent._action_queue_manager.AddAction("ACTION", self._parent._merchant_instance.collector_buy_item,item_id, cost, item_list, item_quantities)
             
         def GetOfferedItems(self):

--- a/Py4GWCoreLib/Item.py
+++ b/Py4GWCoreLib/Item.py
@@ -5,7 +5,7 @@ import PyInventory
 
 from enum import Enum
 
-from Py4GWCoreLib.enums_src.GameData_enums import Attribute, DyeColor
+from Py4GWCoreLib.enums_src.GameData_enums import Attribute, DyeColor, Gender
 from Py4GWCoreLib.enums_src.Item_enums import DAMAGE_RANGES, ItemType, Rarity
 from Py4GWCoreLib.item_mods_src.item_mod import ItemMod
 from Py4GWCoreLib.item_mods_src.item_modifier_parser import ItemModifierParser
@@ -139,6 +139,32 @@ class Item:
             """Purpose: Retrieve the model file ID of an item by its ID."""
             return Item.item_instance(item_id).model_file_id
 
+        @staticmethod
+        def GetCompositeModelIDs(model_file_id) -> list[int]:
+            """Purpose: Retrieve the composite model file IDs of an item by its ID."""
+            return PyItem.PyItem.GetCompositeModelIDs(model_file_id) if model_file_id > 0 else []
+
+        @staticmethod
+        def GetTrueModelFileID(model_file_id, gender : Gender = Gender.Unknown) -> int:
+            """Purpose: Retrieve the "true" model file ID of an item by its ID."""
+            from .Agent import Agent
+            from .Player import Player
+
+            true_id = model_file_id
+            female = Agent.IsFemale(Player.GetAgentID()) if gender == Gender.Unknown else gender == Gender.Female
+            file_ids = Item.GetCompositeModelIDs(model_file_id)
+                        
+            if file_ids:
+                true_id = file_ids[10] if len(file_ids) > 10 else 0
+                
+                if not true_id:
+                    true_id = file_ids[5] if female and len(file_ids) > 5 else file_ids[0]
+                
+                if not true_id:
+                    true_id = model_file_id
+                    
+            return true_id if true_id >= 0 else 0
+        
         @staticmethod
         def GetSlot(item_id):
             """Purpose: Retrieve the slot of an item is in a bag by its ID."""

--- a/Py4GWCoreLib/Merchant.py
+++ b/Py4GWCoreLib/Merchant.py
@@ -1,5 +1,7 @@
 import PyMerchant
 
+from Py4GWCoreLib.py4gwcorelib_src.FrameCache import frame_cache
+
 class Trading:
     @staticmethod
     def merchant_instance():
@@ -43,6 +45,7 @@ class Trading:
             return Trading.merchant_instance().get_quoted_value()
             
         @staticmethod
+        @frame_cache("Trading.Trader", "GetOfferedItems")    
         def GetOfferedItems():
             """
             Purpose: Retrieve the offered items from the Trader.
@@ -53,6 +56,7 @@ class Trading:
             return Trading.merchant_instance().get_trader_item_list()
 
         @staticmethod
+        @frame_cache("Trading.Trader", "GetOfferedItems2")
         def GetOfferedItems2():
             """
             Purpose: Retrieve the offered items from the Trader.
@@ -132,6 +136,7 @@ class Trading:
             Trading.merchant_instance().merchant_sell_item(item_id, cost)
 
         @staticmethod
+        @frame_cache("Trading.Merchant", "GetOfferedItems")
         def GetOfferedItems():
             """
             Purpose: Retrieve the offered items from the merchant.
@@ -156,6 +161,7 @@ class Trading:
             Trading.merchant_instance().crafter_buy_item(item_id, cost, item_list, item_quantities)
 
         @staticmethod
+        @frame_cache("Trading.Crafter", "GetOfferedItems")
         def GetOfferedItems():
             """
             Purpose: Retrieve the offered items from the merchant.
@@ -167,7 +173,7 @@ class Trading:
 
     class Collector:
         @staticmethod
-        def ExghangeItem(item_id, cost =0, item_list=[], item_quantities=[]):
+        def ExchangeItem(item_id, cost =0, item_list=[], item_quantities=[]):
             """
             Purpose: Exchange an item.
             Args:
@@ -180,6 +186,7 @@ class Trading:
             Trading.merchant_instance().collector_buy_item(item_id, cost,  item_list, item_quantities)
 
         @staticmethod
+        @frame_cache("Trading.Collector", "GetOfferedItems")
         def GetOfferedItems():
             """
             Purpose: Retrieve the offered items from the merchant.

--- a/Py4GWCoreLib/enums_src/GameData_enums.py
+++ b/Py4GWCoreLib/enums_src/GameData_enums.py
@@ -48,6 +48,14 @@ class DyeColor(IntEnum):
 
 
 # endregion
+
+#region Gender
+class Gender(IntEnum):
+    Unknown = 0
+    Female = 1
+    Male = 2
+#endregion
+
 # region Profession
 class Profession(IntEnum):
     _None = 0
@@ -338,6 +346,21 @@ class Attribute(IntEnum):
     
     def get_profession(self) -> Profession:
         return _ATTRIBUTE_TO_PROFESSION.get(self, Profession._None)
+    
+    @property
+    def is_primary(self) -> bool:
+        return self in [
+            Attribute.Strength,
+            Attribute.Expertise,
+            Attribute.DivineFavor,
+            Attribute.SoulReaping,
+            Attribute.FastCasting,
+            Attribute.EnergyStorage,
+            Attribute.CriticalStrikes,
+            Attribute.SpawningPower,
+            Attribute.Leadership,
+            Attribute.Mysticism,
+        ]
 
 AttributeNames = {
     Attribute.FastCasting: "Fast Casting",
@@ -391,15 +414,15 @@ AttributeNames = {
 PROFESSION_ATTRIBUTES : dict[Profession, list[Attribute]] = {
     Profession._None: [],
     Profession.Warrior: [Attribute.Strength, Attribute.AxeMastery, Attribute.HammerMastery, Attribute.Swordsmanship, Attribute.Tactics],
-    Profession.Ranger: [Attribute.BeastMastery, Attribute.Expertise, Attribute.WildernessSurvival, Attribute.Marksmanship],
-    Profession.Monk: [Attribute.HealingPrayers, Attribute.SmitingPrayers, Attribute.ProtectionPrayers, Attribute.DivineFavor],
-    Profession.Necromancer: [Attribute.BloodMagic, Attribute.DeathMagic, Attribute.SoulReaping, Attribute.Curses],
+    Profession.Ranger: [Attribute.Expertise, Attribute.BeastMastery, Attribute.WildernessSurvival, Attribute.Marksmanship],
+    Profession.Monk: [Attribute.DivineFavor, Attribute.HealingPrayers, Attribute.SmitingPrayers, Attribute.ProtectionPrayers],
+    Profession.Necromancer: [Attribute.SoulReaping, Attribute.BloodMagic, Attribute.DeathMagic, Attribute.Curses],
     Profession.Mesmer: [Attribute.FastCasting, Attribute.IllusionMagic, Attribute.DominationMagic, Attribute.InspirationMagic],
-    Profession.Elementalist: [Attribute.AirMagic, Attribute.EarthMagic, Attribute.FireMagic, Attribute.WaterMagic],
-    Profession.Assassin: [Attribute.DaggerMastery, Attribute.DeadlyArts, Attribute.ShadowArts, Attribute.CriticalStrikes],
-    Profession.Ritualist: [Attribute.Communing, Attribute.RestorationMagic, Attribute.ChannelingMagic, Attribute.SpawningPower],
-    Profession.Paragon: [Attribute.Command, Attribute.Motivation, Attribute.Leadership, Attribute.SpearMastery],
-    Profession.Dervish: [Attribute.ScytheMastery, Attribute.WindPrayers, Attribute.EarthPrayers, Attribute.Mysticism],
+    Profession.Elementalist: [Attribute.EnergyStorage, Attribute.AirMagic, Attribute.EarthMagic, Attribute.FireMagic, Attribute.WaterMagic],
+    Profession.Assassin: [Attribute.CriticalStrikes, Attribute.DaggerMastery, Attribute.DeadlyArts, Attribute.ShadowArts],
+    Profession.Ritualist: [Attribute.SpawningPower, Attribute.Communing, Attribute.RestorationMagic, Attribute.ChannelingMagic],
+    Profession.Paragon: [Attribute.Leadership, Attribute.Command, Attribute.Motivation, Attribute.SpearMastery],
+    Profession.Dervish: [Attribute.Mysticism, Attribute.ScytheMastery, Attribute.WindPrayers, Attribute.EarthPrayers],
 }
 
 _ATTRIBUTE_TO_PROFESSION: dict[Attribute, Profession] = {}

--- a/Py4GWCoreLib/enums_src/Item_enums.py
+++ b/Py4GWCoreLib/enums_src/Item_enums.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, auto
 from enum import IntEnum
 from .Model_enums import ModelID
 
@@ -58,7 +58,12 @@ class Bags(IntEnum):
     Storage14 = 21
     EquippedItems = 22
 
-
+INVENTORY_BAGS = [Bags.Backpack, Bags.Bag1, Bags.Bag2, Bags.EquipmentPack]
+STORAGE_BAGS = [
+    Bags.Storage1, Bags.Storage2, Bags.Storage3, Bags.Storage4, Bags.Storage5, Bags.Storage6,
+    Bags.Storage7, Bags.Storage8, Bags.Storage9, Bags.Storage10, Bags.Storage11, Bags.Storage12,
+    Bags.Storage13, Bags.Storage14
+]
 # endregion
 # region ItemType
 class ItemType(IntEnum):
@@ -104,6 +109,9 @@ class ItemType(IntEnum):
     Costume_Headpiece = 45
     Unknown = 255
     
+    @property
+    def item_types(self) -> list["ItemType"]:
+        return ITEM_TYPE_META_TYPES.get(self, [self])
     
     @staticmethod
     def is_matching_item_type(item_type: "ItemType", target: "ItemType") -> bool:
@@ -196,6 +204,40 @@ ITEM_TYPE_META_TYPES: dict[ItemType, list[ItemType]] = {
 
 # endregion
 
+class ItemAction(IntEnum):
+    NONE = 0
+    
+    PickUp = auto() # Pick up the item and put it in the inventory.
+    Drop = auto() # Drop the item to the floor the inventory.
+    
+    Hold = auto() # Hold the item in the inventory, no other actions will be performed on it. This can be useful to exclude certain items from being processed by other rules.
+    Stash = auto() # Move the item to the xunlai stash.
+    
+    # Item processing actions:
+    Identify = auto() # Identify the item.
+    ExtractUpgrade = auto() # Extract the upgrades of the item.
+    Salvage_Rare_Materials = auto() # Salvage the item for rare materials with an (Superior) Expert Salvage Kit.
+    Salvage_Common_Materials = auto() # Salvage the item for common materials with a (Basic) Salvage Kit.
+    Destroy = auto() # Destroy the item.
+    
+    # Merchant interactions:
+    Sell_To_Merchant = auto() # Sell the item to a merchant.
+    
+    Sell_To_Trader = auto() # Sell the item to a trader.
+    
+    Use = auto() # Use the item. 
+    
+    ## Some stuff we might be able to implement at some point in the future, but not a priority right now:
+    TradeToPlayer = auto() # Open the trade window with a specific player and offer the item. The player name should be specified in the rule's parameters.
+
+class SalvageMode(IntEnum):
+    NONE = auto()
+    LesserCraftingMaterials = auto()
+    RareCraftingMaterials = auto()
+    Prefix = auto()
+    Suffix = auto()
+    Inscription = auto()
+    
 MaterialMap = {
     ModelID.Bolt_Of_Cloth: "Bolt Of Cloth",
     ModelID.Bone: "Bone",

--- a/Py4GWCoreLib/item_mods_src/item_modifier_parser.py
+++ b/Py4GWCoreLib/item_mods_src/item_modifier_parser.py
@@ -23,55 +23,69 @@ class ItemModifierParser:
                 self.modifiers.append(decoded)
 
     def _build_properties(self):
-        from Py4GWCoreLib.item_mods_src.upgrades import Inherent, _INHERENT_UPGRADES
+        from Py4GWCoreLib.item_mods_src.upgrades import _INHERENT_UPGRADES
         from Py4GWCoreLib.item_mods_src.upgrade_parser import get_property_factory
         handled_modifiers : list[DecodedModifier] = []    
         
-        for mod in self.modifiers:
-            factory = get_property_factory().get(mod.identifier)
-            if factory:
-                prop = factory(mod, self.modifiers, self.rarity)
-                    
-                if prop:
-                    if isinstance(prop, (PrefixProperty, SuffixProperty, InscriptionProperty)):
-                        handled_modifiers.append(prop.modifier)
+        try:
+            for mod in self.modifiers:
+                factory = get_property_factory().get(mod.identifier)
+                if factory:
+                    prop = factory(mod, self.modifiers, self.rarity)
                         
-                        if isinstance(prop, PrefixProperty) and (prefix := cast(PrefixProperty, prop)).upgrade:
-                            for p in prefix.upgrade.properties.values():
-                                if p and p not in handled_modifiers:
-                                    handled_modifiers.append(p.modifier)
+                    if prop:
+                        if isinstance(prop, (PrefixProperty, SuffixProperty, InscriptionProperty)):
+                            handled_modifiers.append(prop.modifier)
+                            
+                            if isinstance(prop, PrefixProperty) and (prefix := cast(PrefixProperty, prop)).upgrade:
+                                for p in prefix.upgrade.properties.values():
+                                    if p and p not in handled_modifiers:
+                                        handled_modifiers.append(p.modifier)
+                            
+                            if isinstance(prop, SuffixProperty) and (suffix := cast(SuffixProperty, prop)).upgrade:
+                                for p in suffix.upgrade.properties.values():
+                                    if p and p not in handled_modifiers:
+                                        handled_modifiers.append(p.modifier)
+                            
+                            if isinstance(prop, InscriptionProperty) and (inscription := cast(InscriptionProperty, prop)).upgrade:
+                                for p in inscription.upgrade.properties.values():
+                                    if p and p not in handled_modifiers:
+                                        handled_modifiers.append(p.modifier)
                         
-                        if isinstance(prop, SuffixProperty) and (suffix := cast(SuffixProperty, prop)).upgrade:
-                            for p in suffix.upgrade.properties.values():
-                                if p and p not in handled_modifiers:
-                                    handled_modifiers.append(p.modifier)
                         
-                        if isinstance(prop, InscriptionProperty) and (inscription := cast(InscriptionProperty, prop)).upgrade:
-                            for p in inscription.upgrade.properties.values():
-                                if p and p not in handled_modifiers:
-                                    handled_modifiers.append(p.modifier)
-                    
-                    
-                    #only add if no property of that type already exists, since some modifiers have multiple entries with the same identifier but different args
-                    # if not any(isinstance(p, type(prop)) and p.modifier.arg == prop.modifier.arg for p in self.properties):
-                    self.properties.append(prop)
+                        #only add if no property of that type already exists, since some modifiers have multiple entries with the same identifier but different args
+                        # if not any(isinstance(p, type(prop)) and p.modifier.arg == prop.modifier.arg for p in self.properties):
+                        self.properties.append(prop)
+                    else:
+                        self.properties.append(ItemProperty(mod, rarity=self.rarity))
                 else:
                     self.properties.append(ItemProperty(mod, rarity=self.rarity))
+            
+            unhandled_modifiers = [mod for mod in self.modifiers if mod not in handled_modifiers]
+            inherent_types = sorted(_INHERENT_UPGRADES, key=lambda u: len(u.upgrade_info), reverse=True)
         
-        unhandled_modifiers = [mod for mod in self.modifiers if mod not in handled_modifiers]
-        inherent_types = sorted(_INHERENT_UPGRADES, key=lambda u: len(u.property_identifiers), reverse=True)
-    
-        for inherent_type in inherent_types:
-            matched_modifiers = inherent_type._match_property_modifiers(unhandled_modifiers)
+            for inherent_type in inherent_types:
+                matched_modifiers = inherent_type._match_property_modifiers(unhandled_modifiers)
 
-            if matched_modifiers is None:
-                continue
+                if matched_modifiers is None:
+                    continue
+                
+                try:
+                    matched_property_modifiers = [prop_mod for _, prop_mod in matched_modifiers]
+                    if not matched_property_modifiers:
+                        continue
 
-            matched_property_modifiers = [prop_mod for _, prop_mod in matched_modifiers]
-            upgrade = inherent_type.compose_from_modifiers(matched_property_modifiers[0], matched_property_modifiers, self.modifiers, self.rarity)
-            if upgrade is not None:
-                self.properties.append(InherentProperty(modifier=matched_property_modifiers[0], rarity=self.rarity, upgrade=upgrade))
-                unhandled_modifiers = [mod for mod in unhandled_modifiers if mod not in matched_property_modifiers]
+                    upgrade = inherent_type.compose_from_modifiers(matched_property_modifiers[0], unhandled_modifiers, self.modifiers, self.rarity)
+                    if upgrade is not None:
+                        self.properties.append(InherentProperty(modifier=matched_property_modifiers[0], rarity=self.rarity, upgrade=upgrade))
+                        unhandled_modifiers = [mod for mod in unhandled_modifiers if mod not in matched_property_modifiers]
+                        
+                except Exception as e:
+                    print(f"Error composing inherent upgrade {inherent_type.__name__}: {e}")
+                    continue
+        
+        except Exception as e:
+            print(f"Error building properties: {e}")
             
     def get_properties(self) -> list[ItemProperty]:
         return self.properties

--- a/Py4GWCoreLib/item_mods_src/properties.py
+++ b/Py4GWCoreLib/item_mods_src/properties.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 from dataclasses import dataclass, field
 from Py4GWCoreLib.enums_src.GameData_enums import Ailment, Attribute, AttributeNames, DamageType, Profession, Reduced_Ailment
 from Py4GWCoreLib.enums_src.Item_enums import ItemType, Rarity
@@ -9,7 +9,7 @@ from Py4GWCoreLib.native_src.internals.encoded_strings import GWStringEncoded, G
 PERSISTENT = True
 
 if TYPE_CHECKING:
-    from Py4GWCoreLib.item_mods_src.upgrades import Inherent, Upgrade
+    from Py4GWCoreLib.item_mods_src.upgrades import Upgrade
 
 @dataclass
 class ItemProperty:
@@ -20,7 +20,7 @@ class ItemProperty:
         self.__encoded_description = self.create_encoded_description()
         
     def create_encoded_description(self) -> GWStringEncoded:
-        return GWStringEncoded(bytes(), f"No description available... ({self.__class__.__name__})")
+        return GWStringEncoded(bytes(), f"Unspecified Item Property.\nIdentifier: {self.modifier.identifier.name} (Id: {self.modifier.identifier}) | Arg1: {self.modifier.arg1} | Arg2: {self.modifier.arg2} | Arg: {self.modifier.arg} | Upgrade Id: {self.modifier.upgrade_id}")
     
     def get_text_color(self) -> bytes:
         match self.rarity:
@@ -50,7 +50,12 @@ class ItemProperty:
     @property
     def plain_description(self) -> str:        
         return self.__encoded_description.plain
-    
+
+@dataclass
+class EmptyProperty(ItemProperty):    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes(), f"Empty Property.\nIdentifier: {self.modifier.identifier.name} (Id: {self.modifier.identifier}) | Arg1: {self.modifier.arg1} | Arg2: {self.modifier.arg2} | Arg: {self.modifier.arg} | Upgrade Id: {self.modifier.upgrade_id}")
+
 @dataclass
 class ArmorProperty(ItemProperty):
     armor: int
@@ -60,7 +65,7 @@ class ArmorProperty(ItemProperty):
         return GWStringEncoded(encoded_bytes, f"Armor: {self.armor}")
     
 @dataclass
-class ArmorEnergyRegen(ItemProperty):
+class EnergyRecovery(ItemProperty):
     energy_regen: int
 
     def create_encoded_description(self) -> GWStringEncoded:
@@ -77,19 +82,19 @@ class ArmorMinusAttacking(ItemProperty):
     
 @dataclass
 class ArmorPenetration(ItemProperty):
-    armor_pen: int
+    armor_penetration: int
     chance: int
 
     def create_encoded_description(self) -> GWStringEncoded:
         encoded = bytes([
             *self.get_text_color(),
-            *GWEncoded.PLUS_PERCENT_TEMPLATE, 0x45, 0xA, 0x1, 0x0, 0x1, 0x1, self.armor_pen, 0x1, 0x1, 0x0,
+            *GWEncoded.PLUS_PERCENT_TEMPLATE, 0x45, 0xA, 0x1, 0x0, 0x1, 0x1, self.armor_penetration, 0x1, 0x1, 0x0,
             *GWEncoded.ITEM_DULL,
             *GWEncoded.PARENTHESIS_STR1,
             *GWEncoded.CHANCE_TEMPLATE, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0,
             0x1, 0x0
         ])
-        return GWStringEncoded(encoded, f"Armor penetration +{self.armor_pen}% (Chance: {self.chance}%)")
+        return GWStringEncoded(encoded, f"Armor penetration +{self.armor_penetration}% (Chance: {self.chance}%)")
     
 @dataclass
 class ArmorPlus(ItemProperty):
@@ -431,12 +436,12 @@ class HealthRegeneneration(ItemProperty):
 
 @dataclass
 class HealthMinus(ItemProperty):
-    health: int
+    health_reduction: int
 
     encoded_string = GWEncoded.HEALTH_MINUS_75
 
     def create_encoded_description(self) -> GWStringEncoded:
-        return GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.HEALTH_BYTES, self.health, "Health")
+        return GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.HEALTH_BYTES, self.health_reduction, "Health")
 
 @dataclass
 class HealthPlus(ItemProperty):
@@ -521,7 +526,7 @@ class OfTheProfession(ItemProperty):
     profession: Profession
 
     def create_encoded_description(self) -> GWStringEncoded:
-        encoded_bytes = bytes([*self.get_text_color(), 0x86, 0xA, 0xA, 0x1, *GWEncoded.ATTRIBUTE_NAMES.get(self.attribute, bytes()), 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x2, 0x81, 0xA8, 0x38, 0x1, 0x0])
+        encoded_bytes = bytes([*self.get_text_color(), 0x86, 0xA, 0xA, 0x1, *GWEncoded.ATTRIBUTE_NAMES.get(self.attribute, bytes()), 0x1, 0x0, 0x1, 0x1, self.attribute_level, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x2, 0x81, 0xA8, 0x38, 0x1, 0x0])
         return GWStringEncoded(encoded_bytes, f"{AttributeNames.get(self.attribute)}: {self.attribute_level} (if your rank is lower. No effect in PvP.)")
 
 @dataclass
@@ -645,7 +650,8 @@ class UnknownUpgradeProperty(ItemProperty):
     upgrade_id: ItemUpgradeId
     
     def create_encoded_description(self) -> GWStringEncoded:
-        return GWStringEncoded(bytes(), f"Unknown Upgrade (ID {self.upgrade_id})")
+        return GWStringEncoded(bytes(), f"Unknown (ID {self.upgrade_id})'\nIdentifier: {self.modifier.identifier.name} (Id: {self.modifier.identifier}) | Arg1: {self.modifier.arg1} | Arg2: {self.modifier.arg2} | Arg: {self.modifier.arg} | Upgrade Id: {self.modifier.upgrade_id.name} ({self.modifier.upgrade_id})")
+
 
 @dataclass
 class InscriptionProperty(ItemProperty):    
@@ -661,7 +667,7 @@ class UpgradeRuneProperty(ItemProperty):
     upgrade: "Upgrade"
 
     def create_encoded_description(self) -> GWStringEncoded:
-        return GWStringEncoded(bytes(), f"RUNE\n{self.upgrade.name if self.upgrade else f'Unknown (ID {self.upgrade_id})'}\n{self.upgrade.description if self.upgrade else ''}\n")
+        return GWStringEncoded(bytes(), f"{self.upgrade.name if self.upgrade else f'Unknown (ID {self.upgrade_id})'}\n{self.upgrade.description if self.upgrade else ''}\n")
     
 @dataclass
 class AppliesToRuneProperty(ItemProperty):    
@@ -672,8 +678,9 @@ class AppliesToRuneProperty(ItemProperty):
         return GWStringEncoded(bytes(), f"{self.upgrade.name if self.upgrade else f'Unknown (ID {self.upgrade_id})'}")
 
 @dataclass
-class TooltipProperty(ItemProperty):
-    pass
+class TooltipProperty(ItemProperty):    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes(), f"Tooltip related property. We don't know yet exactly what this does.\nIdentifier: {self.modifier.identifier.name} (Id: {self.modifier.identifier}) | Arg1: {self.modifier.arg1} | Arg2: {self.modifier.arg2} | Arg: {self.modifier.arg} | Upgrade Id: {self.modifier.upgrade_id}")
 
 @dataclass
 class TargetItemTypeProperty(ItemProperty):

--- a/Py4GWCoreLib/item_mods_src/properties.py
+++ b/Py4GWCoreLib/item_mods_src/properties.py
@@ -253,7 +253,7 @@ class DamagePlusVsSpecies(ItemProperty):
     species: ItemBaneSpecies
 
     def create_encoded_description(self) -> GWStringEncoded:
-        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_percent(self.get_text_color(), bytes([*GWEncoded.DAMAGE_TEXT, 0x1, 0x0]), self.damage_increase, f"Damage +{self.damage_increase}%"), GWEncoded._dull_parenthesized(bytes([*GWEncoded.VS_STR1, *GWEncoded.SLAYING_BANE.get(self.species, bytes())]), f"(vs. {self.species.name})"), f"(vs. {self.species.name})")
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_percent(self.get_text_color(), bytes([*GWEncoded.DAMAGE_TEXT, 0x1, 0x0]), self.damage_increase, f"Damage +{self.damage_increase}%"), GWEncoded._dull_parenthesized(bytes([*GWEncoded.VS_STR1, *GWEncoded.SPECIES.get(self.species, bytes())]), f"(vs. {self.species.name})"), f"(vs. {self.species.name})")
 
 @dataclass
 class DamagePlusWhileBelow(ItemProperty):

--- a/Py4GWCoreLib/item_mods_src/types.py
+++ b/Py4GWCoreLib/item_mods_src/types.py
@@ -1,7 +1,16 @@
+from collections.abc import Callable
+from dataclasses import dataclass
 from enum import Enum, IntEnum, auto
+from typing import Any, Generic, Iterable, Literal, Optional, Protocol, SupportsFloat, SupportsInt, TypeAlias, TypeVar, cast, get_args, get_origin, overload
 
 from Py4GWCoreLib.enums_src.Item_enums import ItemType
 
+class ModifierType(IntEnum):
+    None_ = 0
+    Arg1 = 1
+    Arg2 = 2
+    Fixed = 3
+    
 class ItemBaneSpecies(IntEnum):
     Undead = 0
     Charr = 1
@@ -30,10 +39,11 @@ class ItemUpgradeType(IntEnum):
     AppliesToRune = auto()
     
 class ModifierIdentifier(IntEnum):
-    None_ = 0x0
+    None_ = 0xFFFF
+    Empty = 0x0000
     Armor1 = 0x27b
     Armor2 = 0x23c
-    ArmorEnergyRegen = 0x22e
+    EnergyRecovery = 0x22e
     ArmorMinusAttacking = 0x201
     ArmorPenetration = 0x23f
     ArmorPlus = 0x210
@@ -108,6 +118,13 @@ class ModifierIdentifier(IntEnum):
     TooltipDescription = 0x253
     AttributeRune = 0x21e
     Upgrade = 0x240
+
+ModifierIdentifierSpec: TypeAlias = ModifierIdentifier | tuple[ModifierIdentifier, ...]
+
+def any_of(*identifiers: ModifierIdentifier) -> ModifierIdentifierSpec:
+    if not identifiers:
+        raise ValueError("any_of requires at least one ModifierIdentifier")
+    return identifiers
 
 class ItemUpgradeId(IntEnum):
     Unknown = -1
@@ -524,66 +541,66 @@ class ItemUpgradeId(IntEnum):
     OfSuperiorCommand = 0x2603
     OfSuperiorSpearMastery = 0x2503
     
-    UpgradeMinorRune_Warrior = 0x00B3
-    AppliesToMinorRune_Warrior = 0x0167
-    UpgradeMajorRune_Warrior = 0x00B9
-    AppliesToMajorRune_Warrior = 0x0173
-    UpgradeSuperiorRune_Warrior = 0x00BF
-    AppliesToSuperiorRune_Warrior = 0x017F
-    UpgradeMinorRune_Ranger = 0x00B4
-    AppliesToMinorRune_Ranger = 0x0169
-    UpgradeMajorRune_Ranger = 0x00BA
-    AppliesToMajorRune_Ranger = 0x0175
-    UpgradeSuperiorRune_Ranger = 0x00C0
-    AppliesToSuperiorRune_Ranger = 0x0181
-    UpgradeMinorRune_Monk = 0x00B2
-    AppliesToMinorRune_Monk = 0x0165
-    UpgradeMajorRune_Monk = 0x00B8
-    AppliesToMajorRune_Monk = 0x0171
-    UpgradeSuperiorRune_Monk = 0x00BE
-    AppliesToSuperiorRune_Monk = 0x017D
-    UpgradeMinorRune_Necromancer = 0x00B0
-    AppliesToMinorRune_Necromancer = 0x0161
-    UpgradeMajorRune_Necromancer = 0x00B6
-    AppliesToMajorRune_Necromancer = 0x016D
-    UpgradeSuperiorRune_Necromancer = 0x00BC
-    AppliesToSuperiorRune_Necromancer = 0x0179
-    UpgradeMinorRune_Mesmer = 0x00AF
-    AppliesToMinorRune_Mesmer = 0x015F
-    UpgradeMajorRune_Mesmer = 0x00B5
-    AppliesToMajorRune_Mesmer = 0x016B
-    UpgradeSuperiorRune_Mesmer = 0x00BB
-    AppliesToSuperiorRune_Mesmer = 0x0177
-    UpgradeMinorRune_Elementalist = 0x00B1
-    AppliesToMinorRune_Elementalist = 0x0163
-    UpgradeMajorRune_Elementalist = 0x00B7
-    AppliesToMajorRune_Elementalist = 0x016F
-    UpgradeSuperiorRune_Elementalist = 0x00BD
-    AppliesToSuperiorRune_Elementalist = 0x017B
-    UpgradeMinorRune_Assassin = 0x013B
-    AppliesToMinorRune_Assassin = 0x0277
-    UpgradeMajorRune_Assassin = 0x014C
-    AppliesToMajorRune_Assassin = 0x0279
-    UpgradeSuperiorRune_Assassin = 0x013D
-    AppliesToSuperiorRune_Assassin = 0x027B
-    UpgradeMinorRune_Ritualist = 0x013E
-    AppliesToMinorRune_Ritualist = 0x027D
-    UpgradeMajorRune_Ritualist = 0x013F
-    AppliesToMajorRune_Ritualist = 0x027F
-    UpgradeSuperiorRune_Ritualist = 0x0140
-    AppliesToSuperiorRune_Ritualist = 0x0281
-    UpgradeMinorRune_Dervish = 0x0182
-    AppliesToMinorRune_Dervish = 0x0305
-    UpgradeMajorRune_Dervish = 0x0183
-    AppliesToMajorRune_Dervish = 0x0307
-    UpgradeSuperiorRune_Dervish = 0x0184
-    AppliesToSuperiorRune_Dervish = 0x0309
-    UpgradeMinorRune_Paragon = 0x0185
-    AppliesToMinorRune_Paragon = 0x030B
-    UpgradeMajorRune_Paragon = 0x0186
-    AppliesToMajorRune_Paragon = 0x030D
-    UpgradeSuperiorRune_Paragon = 0x0187
-    AppliesToSuperiorRune_Paragon = 0x030F
+    MinorWarriorRune = 0x00B3
+    AppliesToMinorWarriorRune = 0x0167
+    MajorWarriorRune = 0x00B9
+    AppliesToMajorWarriorRune = 0x0173
+    SuperiorWarriorRune = 0x00BF
+    AppliesToSuperiorWarriorRune = 0x017F
+    MinorRangerRune = 0x00B4
+    AppliesToMinorRangerRune = 0x0169
+    MajorRangerRune = 0x00BA
+    AppliesToMajorRangerRune = 0x0175
+    SuperiorRangerRune = 0x00C0
+    AppliesToSuperiorRangerRune = 0x0181
+    MinorMonkRune = 0x00B2
+    AppliesToMinorMonkRune = 0x0165
+    MajorMonkRune = 0x00B8
+    AppliesToMajorMonkRune = 0x0171
+    SuperiorMonkRune = 0x00BE
+    AppliesToSuperiorMonkRune = 0x017D
+    MinorNecromancerRune = 0x00B0
+    AppliesToMinorNecromancerRune = 0x0161
+    MajorNecromancerRune = 0x00B6
+    AppliesToMajorNecromancerRune = 0x016D
+    SuperiorNecromancerRune = 0x00BC
+    AppliesToSuperiorNecromancerRune = 0x0179
+    MinorMesmerRune = 0x00AF
+    AppliesToMinorMesmerRune = 0x015F
+    MajorMesmerRune = 0x00B5
+    AppliesToMajorMesmerRune = 0x016B
+    SuperiorMesmerRune = 0x00BB
+    AppliesToSuperiorMesmerRune = 0x0177
+    MinorElementalistRune = 0x00B1
+    AppliesToMinorElementalistRune = 0x0163
+    MajorElementalistRune = 0x00B7
+    AppliesToMajorElementalistRune = 0x016F
+    SuperiorElementalistRune = 0x00BD
+    AppliesToSuperiorElementalistRune = 0x017B
+    MinorAssassinRune = 0x013B
+    AppliesToMinorAssassinRune = 0x0277
+    MajorAssassinRune = 0x013C
+    AppliesToMajorAssassinRune = 0x0279
+    SuperiorAssassinRune = 0x013D
+    AppliesToSuperiorAssassinRune = 0x027B
+    MinorRitualistRune = 0x013E
+    AppliesToMinorRitualistRune = 0x027D
+    MajorRitualistRune = 0x013F
+    AppliesToMajorRitualistRune = 0x027F
+    SuperiorRitualistRune = 0x0140
+    AppliesToSuperiorRitualistRune = 0x0281
+    MinorDervishRune = 0x0182
+    AppliesToMinorDervishRune = 0x0305
+    MajorDervishRune = 0x0183
+    AppliesToMajorDervishRune = 0x0307
+    SuperiorDervishRune = 0x0184
+    AppliesToSuperiorDervishRune = 0x0309
+    MinorParagonRune = 0x0185
+    AppliesToMinorParagonRune = 0x030B
+    MajorParagonRune = 0x0186
+    AppliesToMajorParagonRune = 0x030D
+    SuperiorParagonRune = 0x0187
+    AppliesToSuperiorParagonRune = 0x030F
 
 class ItemUpgrade(Enum):
     Unknown = ItemUpgradeId.Unknown
@@ -688,14 +705,16 @@ class ItemUpgrade(Enum):
         ItemType.Spear: ItemUpgradeId.Zealous_Spear,
         ItemType.Sword: ItemUpgradeId.Zealous_Sword,
     }
-    Vampiric = {
+    VampiricMinor = {
         ItemType.Axe: ItemUpgradeId.Vampiric_Axe,
-        ItemType.Bow: ItemUpgradeId.Vampiric_Bow,
+        ItemType.Sword: ItemUpgradeId.Vampiric_Sword,
         ItemType.Daggers: ItemUpgradeId.Vampiric_Daggers,
+        ItemType.Spear: ItemUpgradeId.Vampiric_Spear,
+    }
+    VampiricMajor = {
+        ItemType.Bow: ItemUpgradeId.Vampiric_Bow,
         ItemType.Hammer: ItemUpgradeId.Vampiric_Hammer,
         ItemType.Scythe: ItemUpgradeId.Vampiric_Scythe,
-        ItemType.Spear: ItemUpgradeId.Vampiric_Spear,
-        ItemType.Sword: ItemUpgradeId.Vampiric_Sword,
     }
     Swift = {
         ItemType.Staff: ItemUpgradeId.Swift_Staff,
@@ -971,12 +990,6 @@ class ItemUpgrade(Enum):
     WarriorRuneOfSuperiorAxeMastery = ItemUpgradeId.OfSuperiorAxeMastery
     WarriorRuneOfSuperiorHammerMastery = ItemUpgradeId.OfSuperiorHammerMastery
     WarriorRuneOfSuperiorSwordsmanship = ItemUpgradeId.OfSuperiorSwordsmanship
-    UpgradeMinorRuneWarrior = ItemUpgradeId.UpgradeMinorRune_Warrior
-    UpgradeMajorRuneWarrior = ItemUpgradeId.UpgradeMajorRune_Warrior
-    UpgradeSuperiorRuneWarrior = ItemUpgradeId.UpgradeSuperiorRune_Warrior
-    AppliesToMinorRuneWarrior = ItemUpgradeId.AppliesToMinorRune_Warrior
-    AppliesToMajorRuneWarrior = ItemUpgradeId.AppliesToMajorRune_Warrior
-    AppliesToSuperiorRuneWarrior = ItemUpgradeId.AppliesToSuperiorRune_Warrior
     
     RangerRuneOfMinorWildernessSurvival = ItemUpgradeId.OfMinorWildernessSurvival
     RangerRuneOfMinorExpertise = ItemUpgradeId.OfMinorExpertise
@@ -990,12 +1003,6 @@ class ItemUpgrade(Enum):
     RangerRuneOfSuperiorExpertise = ItemUpgradeId.OfSuperiorExpertise
     RangerRuneOfSuperiorBeastMastery = ItemUpgradeId.OfSuperiorBeastMastery
     RangerRuneOfSuperiorMarksmanship = ItemUpgradeId.OfSuperiorMarksmanship
-    UpgradeMinorRuneRanger = ItemUpgradeId.UpgradeMinorRune_Ranger
-    UpgradeMajorRuneRanger = ItemUpgradeId.UpgradeMajorRune_Ranger
-    UpgradeSuperiorRuneRanger = ItemUpgradeId.UpgradeSuperiorRune_Ranger
-    AppliesToMinorRuneRanger = ItemUpgradeId.AppliesToMinorRune_Ranger
-    AppliesToMajorRuneRanger = ItemUpgradeId.AppliesToMajorRune_Ranger
-    AppliesToSuperiorRuneRanger = ItemUpgradeId.AppliesToSuperiorRune_Ranger
     
     MonkRuneOfMinorHealingPrayers = ItemUpgradeId.OfMinorHealingPrayers
     MonkRuneOfMinorSmitingPrayers = ItemUpgradeId.OfMinorSmitingPrayers
@@ -1009,12 +1016,6 @@ class ItemUpgrade(Enum):
     MonkRuneOfSuperiorSmitingPrayers = ItemUpgradeId.OfSuperiorSmitingPrayers
     MonkRuneOfSuperiorProtectionPrayers = ItemUpgradeId.OfSuperiorProtectionPrayers
     MonkRuneOfSuperiorDivineFavor = ItemUpgradeId.OfSuperiorDivineFavor
-    UpgradeMinorRuneMonk = ItemUpgradeId.UpgradeMinorRune_Monk
-    UpgradeMajorRuneMonk = ItemUpgradeId.UpgradeMajorRune_Monk
-    UpgradeSuperiorRuneMonk = ItemUpgradeId.UpgradeSuperiorRune_Monk
-    AppliesToMinorRuneMonk = ItemUpgradeId.AppliesToMinorRune_Monk
-    AppliesToMajorRuneMonk = ItemUpgradeId.AppliesToMajorRune_Monk
-    AppliesToSuperiorRuneMonk = ItemUpgradeId.AppliesToSuperiorRune_Monk
     
     NecromancerRuneOfMinorBloodMagic = ItemUpgradeId.OfMinorBloodMagic
     NecromancerRuneOfMinorDeathMagic = ItemUpgradeId.OfMinorDeathMagic
@@ -1028,12 +1029,6 @@ class ItemUpgrade(Enum):
     NecromancerRuneOfSuperiorDeathMagic = ItemUpgradeId.OfSuperiorDeathMagic
     NecromancerRuneOfSuperiorCurses = ItemUpgradeId.OfSuperiorCurses
     NecromancerRuneOfSuperiorSoulReaping = ItemUpgradeId.OfSuperiorSoulReaping
-    UpgradeMinorRuneNecromancer = ItemUpgradeId.UpgradeMinorRune_Necromancer
-    UpgradeMajorRuneNecromancer = ItemUpgradeId.UpgradeMajorRune_Necromancer
-    UpgradeSuperiorRuneNecromancer = ItemUpgradeId.UpgradeSuperiorRune_Necromancer
-    AppliesToMinorRuneNecromancer = ItemUpgradeId.AppliesToMinorRune_Necromancer
-    AppliesToMajorRuneNecromancer = ItemUpgradeId.AppliesToMajorRune_Necromancer
-    AppliesToSuperiorRuneNecromancer = ItemUpgradeId.AppliesToSuperiorRune_Necromancer
     
     MesmerRuneOfMinorFastCasting = ItemUpgradeId.OfMinorFastCasting
     MesmerRuneOfMinorDominationMagic = ItemUpgradeId.OfMinorDominationMagic
@@ -1047,12 +1042,6 @@ class ItemUpgrade(Enum):
     MesmerRuneOfSuperiorDominationMagic = ItemUpgradeId.OfSuperiorDominationMagic
     MesmerRuneOfSuperiorIllusionMagic = ItemUpgradeId.OfSuperiorIllusionMagic
     MesmerRuneOfSuperiorInspirationMagic = ItemUpgradeId.OfSuperiorInspirationMagic
-    UpgradeMinorRuneMesmer = ItemUpgradeId.UpgradeMinorRune_Mesmer
-    UpgradeMajorRuneMesmer = ItemUpgradeId.UpgradeMajorRune_Mesmer
-    UpgradeSuperiorRuneMesmer = ItemUpgradeId.UpgradeSuperiorRune_Mesmer
-    AppliesToMinorRuneMesmer = ItemUpgradeId.AppliesToMinorRune_Mesmer
-    AppliesToMajorRuneMesmer = ItemUpgradeId.AppliesToMajorRune_Mesmer
-    AppliesToSuperiorRuneMesmer = ItemUpgradeId.AppliesToSuperiorRune_Mesmer
     
     ElementalistRuneOfMinorEnergyStorage = ItemUpgradeId.OfMinorEnergyStorage
     ElementalistRuneOfMinorFireMagic = ItemUpgradeId.OfMinorFireMagic
@@ -1069,12 +1058,6 @@ class ItemUpgrade(Enum):
     ElementalistRuneOfSuperiorAirMagic = ItemUpgradeId.OfSuperiorAirMagic
     ElementalistRuneOfSuperiorEarthMagic = ItemUpgradeId.OfSuperiorEarthMagic
     ElementalistRuneOfSuperiorWaterMagic = ItemUpgradeId.OfSuperiorWaterMagic
-    UpgradeMinorRuneElementalist = ItemUpgradeId.UpgradeMinorRune_Elementalist
-    UpgradeMajorRuneElementalist = ItemUpgradeId.UpgradeMajorRune_Elementalist
-    UpgradeSuperiorRuneElementalist = ItemUpgradeId.UpgradeSuperiorRune_Elementalist
-    AppliesToMinorRuneElementalist = ItemUpgradeId.AppliesToMinorRune_Elementalist
-    AppliesToMajorRuneElementalist = ItemUpgradeId.AppliesToMajorRune_Elementalist
-    AppliesToSuperiorRuneElementalist = ItemUpgradeId.AppliesToSuperiorRune_Elementalist
     
     AssassinRuneOfMinorCriticalStrikes = ItemUpgradeId.OfMinorCriticalStrikes
     AssassinRuneOfMinorDaggerMastery = ItemUpgradeId.OfMinorDaggerMastery
@@ -1088,12 +1071,6 @@ class ItemUpgrade(Enum):
     AssassinRuneOfSuperiorDaggerMastery = ItemUpgradeId.OfSuperiorDaggerMastery
     AssassinRuneOfSuperiorDeadlyArts = ItemUpgradeId.OfSuperiorDeadlyArts
     AssassinRuneOfSuperiorShadowArts = ItemUpgradeId.OfSuperiorShadowArts
-    UpgradeMinorRuneAssassin = ItemUpgradeId.UpgradeMinorRune_Assassin
-    UpgradeMajorRuneAssassin = ItemUpgradeId.UpgradeMajorRune_Assassin
-    UpgradeSuperiorRuneAssassin = ItemUpgradeId.UpgradeSuperiorRune_Assassin
-    AppliesToMinorRuneAssassin = ItemUpgradeId.AppliesToMinorRune_Assassin
-    AppliesToMajorRuneAssassin = ItemUpgradeId.AppliesToMajorRune_Assassin
-    AppliesToSuperiorRuneAssassin = ItemUpgradeId.AppliesToSuperiorRune_Assassin
     
     RitualistRuneOfMinorChannelingMagic = ItemUpgradeId.OfMinorChannelingMagic
     RitualistRuneOfMinorRestorationMagic = ItemUpgradeId.OfMinorRestorationMagic
@@ -1107,12 +1084,6 @@ class ItemUpgrade(Enum):
     RitualistRuneOfSuperiorRestorationMagic = ItemUpgradeId.OfSuperiorRestorationMagic
     RitualistRuneOfSuperiorCommuning = ItemUpgradeId.OfSuperiorCommuning
     RitualistRuneOfSuperiorSpawningPower = ItemUpgradeId.OfSuperiorSpawningPower
-    UpgradeMinorRuneRitualist = ItemUpgradeId.UpgradeMinorRune_Ritualist
-    UpgradeMajorRuneRitualist = ItemUpgradeId.UpgradeMajorRune_Ritualist
-    UpgradeSuperiorRuneRitualist = ItemUpgradeId.UpgradeSuperiorRune_Ritualist
-    AppliesToMinorRuneRitualist = ItemUpgradeId.AppliesToMinorRune_Ritualist
-    AppliesToMajorRuneRitualist = ItemUpgradeId.AppliesToMajorRune_Ritualist
-    AppliesToSuperiorRuneRitualist = ItemUpgradeId.AppliesToSuperiorRune_Ritualist
     
     DervishRuneOfMinorMysticism = ItemUpgradeId.OfMinorMysticism
     DervishRuneOfMinorEarthPrayers = ItemUpgradeId.OfMinorEarthPrayers
@@ -1126,12 +1097,6 @@ class ItemUpgrade(Enum):
     DervishRuneOfSuperiorEarthPrayers = ItemUpgradeId.OfSuperiorEarthPrayers
     DervishRuneOfSuperiorScytheMastery = ItemUpgradeId.OfSuperiorScytheMastery
     DervishRuneOfSuperiorWindPrayers = ItemUpgradeId.OfSuperiorWindPrayers
-    UpgradeMinorRuneDervish = ItemUpgradeId.UpgradeMinorRune_Dervish
-    UpgradeMajorRuneDervish = ItemUpgradeId.UpgradeMajorRune_Dervish
-    UpgradeSuperiorRuneDervish = ItemUpgradeId.UpgradeSuperiorRune_Dervish
-    AppliesToMinorRuneDervish = ItemUpgradeId.AppliesToMinorRune_Dervish
-    AppliesToMajorRuneDervish = ItemUpgradeId.AppliesToMajorRune_Dervish
-    AppliesToSuperiorRuneDervish = ItemUpgradeId.AppliesToSuperiorRune_Dervish
     
     ParagonRuneOfMinorLeadership = ItemUpgradeId.OfMinorLeadership
     ParagonRuneOfMinorMotivation = ItemUpgradeId.OfMinorMotivation
@@ -1145,12 +1110,90 @@ class ItemUpgrade(Enum):
     ParagonRuneOfSuperiorMotivation = ItemUpgradeId.OfSuperiorMotivation
     ParagonRuneOfSuperiorCommand = ItemUpgradeId.OfSuperiorCommand
     ParagonRuneOfSuperiorSpearMastery = ItemUpgradeId.OfSuperiorSpearMastery
-    UpgradeMinorRuneParagon = ItemUpgradeId.UpgradeMinorRune_Paragon
-    UpgradeMajorRuneParagon = ItemUpgradeId.UpgradeMajorRune_Paragon
-    UpgradeSuperiorRuneParagon = ItemUpgradeId.UpgradeSuperiorRune_Paragon
-    AppliesToMinorRuneParagon = ItemUpgradeId.AppliesToMinorRune_Paragon
-    AppliesToMajorRuneParagon = ItemUpgradeId.AppliesToMajorRune_Paragon
-    AppliesToSuperiorRuneParagon = ItemUpgradeId.AppliesToSuperiorRune_Paragon
+    
+    UpgradeRune = [
+        ItemUpgradeId.MinorWarriorRune,
+        ItemUpgradeId.MajorWarriorRune,
+        ItemUpgradeId.SuperiorWarriorRune,
+        
+        ItemUpgradeId.MinorRangerRune,
+        ItemUpgradeId.MajorRangerRune,
+        ItemUpgradeId.SuperiorRangerRune,
+        
+        ItemUpgradeId.MinorMonkRune,
+        ItemUpgradeId.MajorMonkRune,
+        ItemUpgradeId.SuperiorMonkRune,
+        
+        ItemUpgradeId.MinorNecromancerRune,
+        ItemUpgradeId.MajorNecromancerRune,
+        ItemUpgradeId.SuperiorNecromancerRune,
+        
+        ItemUpgradeId.MinorMesmerRune,
+        ItemUpgradeId.MajorMesmerRune,
+        ItemUpgradeId.SuperiorMesmerRune,
+        
+        ItemUpgradeId.MinorElementalistRune,
+        ItemUpgradeId.MajorElementalistRune,
+        ItemUpgradeId.SuperiorElementalistRune,
+        
+        ItemUpgradeId.MinorAssassinRune,
+        ItemUpgradeId.MajorAssassinRune,
+        ItemUpgradeId.SuperiorAssassinRune,
+        
+        ItemUpgradeId.MinorRitualistRune,
+        ItemUpgradeId.MajorRitualistRune,
+        ItemUpgradeId.SuperiorRitualistRune,
+        
+        ItemUpgradeId.MinorDervishRune,
+        ItemUpgradeId.MajorDervishRune,
+        ItemUpgradeId.SuperiorDervishRune,
+
+        ItemUpgradeId.MinorParagonRune,
+        ItemUpgradeId.MajorParagonRune,
+        ItemUpgradeId.SuperiorParagonRune,
+    ]
+    
+    AppliesToRune = [
+        ItemUpgradeId.AppliesToMinorWarriorRune,
+        ItemUpgradeId.AppliesToMajorWarriorRune,
+        ItemUpgradeId.AppliesToSuperiorWarriorRune,
+        
+        ItemUpgradeId.AppliesToMinorRangerRune,
+        ItemUpgradeId.AppliesToMajorRangerRune,
+        ItemUpgradeId.AppliesToSuperiorRangerRune,
+        
+        ItemUpgradeId.AppliesToMinorMonkRune,
+        ItemUpgradeId.AppliesToMajorMonkRune,
+        ItemUpgradeId.AppliesToSuperiorMonkRune,
+        
+        ItemUpgradeId.AppliesToMinorNecromancerRune,
+        ItemUpgradeId.AppliesToMajorNecromancerRune,
+        ItemUpgradeId.AppliesToSuperiorNecromancerRune,
+        
+        ItemUpgradeId.AppliesToMinorMesmerRune,
+        ItemUpgradeId.AppliesToMajorMesmerRune,
+        ItemUpgradeId.AppliesToSuperiorMesmerRune,
+        
+        ItemUpgradeId.AppliesToMinorElementalistRune,
+        ItemUpgradeId.AppliesToMajorElementalistRune,
+        ItemUpgradeId.AppliesToSuperiorElementalistRune,
+        
+        ItemUpgradeId.AppliesToMinorAssassinRune,
+        ItemUpgradeId.AppliesToMajorAssassinRune,
+        ItemUpgradeId.AppliesToSuperiorAssassinRune,
+        
+        ItemUpgradeId.AppliesToMinorRitualistRune,
+        ItemUpgradeId.AppliesToMajorRitualistRune,
+        ItemUpgradeId.AppliesToSuperiorRitualistRune,
+        
+        ItemUpgradeId.AppliesToMinorDervishRune,
+        ItemUpgradeId.AppliesToMajorDervishRune,
+        ItemUpgradeId.AppliesToSuperiorDervishRune,
+
+        ItemUpgradeId.AppliesToMinorParagonRune,
+        ItemUpgradeId.AppliesToMajorParagonRune,
+        ItemUpgradeId.AppliesToSuperiorParagonRune,
+    ]
         
     @property
     def item_type_id_map(self) -> dict[ItemType, "ItemUpgradeId"]:
@@ -1160,6 +1203,9 @@ class ItemUpgrade(Enum):
     def upgrade_ids(self) -> tuple["ItemUpgradeId", ...]:
         if isinstance(self.value, dict):
             return tuple(self.value.values())
+        
+        if isinstance(self.value, list):
+            return tuple(self.value)
         
         return (self.value,)
 
@@ -1174,5 +1220,12 @@ class ItemUpgrade(Enum):
     def has_id(self, upgrade_id: "ItemUpgradeId") -> bool:
         if isinstance(self.value, dict):
             return upgrade_id in self.value.values()
+
+        if isinstance(self.value, list):
+            return upgrade_id in self.value
         
-        return upgrade_id == self.value    
+        return upgrade_id == self.value
+    
+
+
+

--- a/Py4GWCoreLib/item_mods_src/upgrade_parser.py
+++ b/Py4GWCoreLib/item_mods_src/upgrade_parser.py
@@ -45,12 +45,21 @@ def get_upgrade_property(modifier: DecodedModifier, all_modifiers: list[DecodedM
     return None
 
 def get_upgrade(modifier : DecodedModifier, remaining_modifiers: list[DecodedModifier], all_modifiers: list[DecodedModifier], upgrade_type: ItemUpgradeType | None = None, rarity: Rarity = Rarity.Blue) -> tuple["Upgrade", ItemUpgradeType]:
-    creator_type = next((t for t in _UPGRADES if t.has_id(modifier.upgrade_id) and (upgrade_type is None or t.mod_type == upgrade_type)), None)     
+    creator_types = [t for t in _UPGRADES if t.has_id(modifier.upgrade_id) and (upgrade_type is None or t.mod_type == upgrade_type)]
+    matches: list[tuple[type[Upgrade], Upgrade]] = []
 
-    if creator_type is not None:        
-        upgrade = creator_type.compose_from_modifiers(modifier, remaining_modifiers, all_modifiers, rarity)
-        if upgrade is not None:
-            return upgrade, creator_type.mod_type
+    for creator_type in creator_types:
+        if creator_type is not None:
+            upgrade = creator_type.compose_from_modifiers(modifier, remaining_modifiers.copy(), all_modifiers, rarity)
+            if upgrade is not None:
+                matches.append((creator_type, upgrade))
+
+    if matches:
+        best_creator_type, best_upgrade = max(
+            matches,
+            key=lambda entry: entry[0].get_specificity_score(),
+        )
+        return best_upgrade, best_creator_type.mod_type
         
     return UnknownUpgrade(), ItemUpgradeType.Unknown
 
@@ -73,11 +82,11 @@ def get_item_requirement(modifiers: list[DecodedModifier]) -> Attribute:
 
 def get_property_factory() -> dict[ModifierIdentifier, Callable[[DecodedModifier, list[DecodedModifier], Rarity], ItemProperty]]:
     return {
+        ModifierIdentifier.Empty: lambda m, _, rarity: EmptyProperty(modifier=m, rarity=rarity),
         ModifierIdentifier.Armor1: lambda m, _, rarity: ArmorProperty(modifier=m, armor=m.arg1, rarity=rarity),
         ModifierIdentifier.Armor2: lambda m, _, rarity: ArmorProperty(modifier=m, armor=m.arg1, rarity=rarity),
-        ModifierIdentifier.ArmorEnergyRegen: lambda m, _, rarity: ArmorEnergyRegen(modifier=m, energy_regen=m.arg1, rarity=rarity),
         ModifierIdentifier.ArmorMinusAttacking: lambda m, _, rarity: ArmorMinusAttacking(modifier=m, armor=m.arg2, rarity=rarity),
-        ModifierIdentifier.ArmorPenetration: lambda m, _, rarity: ArmorPenetration(modifier=m, armor_pen=m.arg2, chance=m.arg1, rarity=rarity),
+        ModifierIdentifier.ArmorPenetration: lambda m, _, rarity: ArmorPenetration(modifier=m, armor_penetration=m.arg2, chance=m.arg1, rarity=rarity),
         ModifierIdentifier.ArmorPlus: lambda m, _, rarity: ArmorPlus(modifier=m, armor=m.arg2, rarity=rarity),
         ModifierIdentifier.ArmorPlusAttacking: lambda m, _, rarity: ArmorPlusAttacking(modifier=m, armor=m.arg2, rarity=rarity),
         ModifierIdentifier.ArmorPlusCasting: lambda m, _, rarity: ArmorPlusCasting(modifier=m, armor=m.arg2, rarity=rarity),
@@ -108,7 +117,8 @@ def get_property_factory() -> dict[ModifierIdentifier, Callable[[DecodedModifier
         ModifierIdentifier.DamageTypeProperty: lambda m, _, rarity: DamageTypeProperty(modifier=m, damage_type=DamageType(m.arg1), rarity=rarity),
         ModifierIdentifier.Energy: lambda m, _, rarity: EnergyProperty(modifier=m, energy=m.arg1, rarity=rarity),
         ModifierIdentifier.Energy2: lambda m, _, rarity: EnergyProperty(modifier=m, energy=m.arg1, rarity=rarity),
-        ModifierIdentifier.EnergyRegeneration: lambda m, _, rarity: EnergyRegeneration(modifier=m, energy_regeneration=m.arg2, rarity=rarity),
+        ModifierIdentifier.EnergyRecovery: lambda m, _, rarity: EnergyRecovery(modifier=m, energy_regen=m.arg1, rarity=rarity),
+        ModifierIdentifier.EnergyRegeneration: lambda m, _, rarity: EnergyRegeneration(modifier=m, energy_regeneration=-m.arg2, rarity=rarity),
         ModifierIdentifier.EnergyGainOnHit: lambda m, _, rarity: EnergyGainOnHit(modifier=m, energy_gain=m.arg2, rarity=rarity),
         ModifierIdentifier.EnergyMinus: lambda m, _, rarity: EnergyMinus(modifier=m, energy=m.arg2, rarity=rarity),
         ModifierIdentifier.EnergyPlus : lambda m, _, rarity: EnergyPlus(modifier=m, energy=m.arg2, rarity=rarity),
@@ -126,7 +136,7 @@ def get_property_factory() -> dict[ModifierIdentifier, Callable[[DecodedModifier
         ModifierIdentifier.HeadpieceAttribute: lambda m, _, rarity: HeadpieceAttribute(modifier=m, attribute=Attribute(m.arg1), attribute_level=m.arg2, rarity=rarity),
         ModifierIdentifier.HeadpieceGenericAttribute: lambda m, _, rarity: HeadpieceGenericAttribute(modifier=m, rarity=rarity),
         ModifierIdentifier.HealthRegeneneration: lambda m, _, rarity: HealthRegeneneration(modifier=m, health_regeneration=-m.arg2, rarity=rarity),
-        ModifierIdentifier.HealthMinus: lambda m, _, rarity: HealthMinus(modifier=m, health=m.arg2, rarity=rarity),
+        ModifierIdentifier.HealthMinus: lambda m, _, rarity: HealthMinus(modifier=m, health_reduction=m.arg2, rarity=rarity),
         ModifierIdentifier.HealthPlus: lambda m, _, rarity: HealthPlus(modifier=m, health=m.arg1, rarity=rarity),
         ModifierIdentifier.HealthPlus2 : lambda m, _, rarity: HealthPlus(modifier=m, health=m.arg2, rarity=rarity),
         ModifierIdentifier.HealthPlusEnchanted: lambda m, _, rarity: HealthPlusEnchanted(modifier=m, health=m.arg1, rarity=rarity),
@@ -147,13 +157,21 @@ def get_property_factory() -> dict[ModifierIdentifier, Callable[[DecodedModifier
         ModifierIdentifier.ReducesDiseaseDuration: lambda m, _, rarity: ReducesDiseaseDuration(modifier=m, rarity=rarity),
         ModifierIdentifier.ReceiveLessDamage: lambda m, _, rarity: ReceiveLessDamage(modifier=m, damage_reduction=m.arg2, chance=m.arg1, rarity=rarity),
         ModifierIdentifier.TargetItemType: lambda m, _, rarity: TargetItemTypeProperty(modifier=m, item_type=ItemType(m.arg1), rarity=rarity),
+        ModifierIdentifier.TooltipDescription: lambda m, _, rarity: TooltipProperty(modifier=m, rarity=rarity),
         
-        ModifierIdentifier.AttributeRune: lambda m, mods, rarity:   get_upgrade_property(m, mods, ItemUpgradeType.Suffix, rarity) or
+        ModifierIdentifier.AttributeRune: lambda m, mods, rarity:  
+                                                            get_upgrade_property(m, mods, ItemUpgradeType.Prefix, rarity) or
+                                                            get_upgrade_property(m, mods, ItemUpgradeType.Inscription, rarity) or
+                                                            get_upgrade_property(m, mods, ItemUpgradeType.Suffix, rarity) or
+                                                            get_upgrade_property(m, mods, ItemUpgradeType.UpgradeRune, rarity) or
+                                                            get_upgrade_property(m, mods, ItemUpgradeType.AppliesToRune, rarity) or
                                                             UnknownUpgradeProperty(modifier=m, upgrade_id=m.upgrade_id, rarity=rarity),
                                                             
         ModifierIdentifier.Upgrade: lambda m, mods, rarity: 
-                                                                        get_upgrade_property(m, mods, ItemUpgradeType.Prefix, rarity) or
-                                                                        get_upgrade_property(m, mods, ItemUpgradeType.Inscription, rarity) or
-                                                                        get_upgrade_property(m, mods, ItemUpgradeType.Suffix, rarity) or
-                                                                        UnknownUpgradeProperty(modifier=m, upgrade_id=m.upgrade_id, rarity=rarity),
+                                                            get_upgrade_property(m, mods, ItemUpgradeType.Prefix, rarity) or
+                                                            get_upgrade_property(m, mods, ItemUpgradeType.Inscription, rarity) or
+                                                            get_upgrade_property(m, mods, ItemUpgradeType.Suffix, rarity) or
+                                                            get_upgrade_property(m, mods, ItemUpgradeType.UpgradeRune, rarity) or
+                                                            get_upgrade_property(m, mods, ItemUpgradeType.AppliesToRune, rarity) or
+                                                            UnknownUpgradeProperty(modifier=m, upgrade_id=m.upgrade_id, rarity=rarity),
     }

--- a/Py4GWCoreLib/item_mods_src/upgrades.py
+++ b/Py4GWCoreLib/item_mods_src/upgrades.py
@@ -1,51 +1,162 @@
 from dataclasses import MISSING, dataclass, field, fields, is_dataclass
-from enum import Enum, IntEnum
+from enum import Enum
 import re
-from typing import Any, ClassVar, Optional, TypeAlias, cast
+from typing import Any, Callable, ClassVar, Generic, Optional, Protocol, SupportsFloat, SupportsInt, TypeVar, cast
 
-import Py4GW
-from PyItem import ItemModifier
-
-from Py4GWCoreLib.enums_src.GameData_enums import Ailment, Attribute, AttributeNames, DamageType, Profession, Reduced_Ailment
+from Py4GWCoreLib.enums_src.GameData_enums import Ailment, Attribute, AttributeNames, DamageType, PROFESSION_ATTRIBUTES, Profession, Reduced_Ailment
 from Py4GWCoreLib.enums_src.Item_enums import ItemType, Rarity
 from Py4GWCoreLib.enums_src.Region_enums import ServerLanguage
-from Py4GWCoreLib.native_src.internals import string_table
 from Py4GWCoreLib.item_mods_src.decoded_modifier import DecodedModifier
-from Py4GWCoreLib.item_mods_src.properties import ItemProperty
-from Py4GWCoreLib.item_mods_src.types import ItemBaneSpecies, ItemModifierParam, ItemUpgrade, ItemUpgradeId, ItemUpgradeType, ModifierIdentifier
-from Py4GWCoreLib.native_src.internals.encoded_strings import GWStringEncoded, GWEncoded
-from Py4GWCoreLib.py4gwcorelib_src.Utils import Utils
+from Py4GWCoreLib.item_mods_src.types import ItemBaneSpecies, ItemUpgrade, ItemUpgradeId, ItemUpgradeType, ModifierIdentifier, ModifierIdentifierSpec, any_of
+from Py4GWCoreLib.native_src.internals import string_table
+from Py4GWCoreLib.native_src.internals.encoded_strings import GWEncoded, GWStringEncoded
 
-ModifierIdentifierSpec: TypeAlias = ModifierIdentifier | tuple[ModifierIdentifier, ...]
+from Py4GWCoreLib.item_mods_src.properties import *
 
-def any_of(*identifiers: ModifierIdentifier) -> ModifierIdentifierSpec:
-    if not identifiers:
-        raise ValueError("any_of requires at least one ModifierIdentifier")
-    return identifiers
+PERSISTENT = True
+
+class NumericValue(SupportsInt, SupportsFloat, Protocol):
+    """Protocol for values that behave like orderable numeric types."""
+
+    def __lt__(self, other: Any, /) -> bool: ...
+    def __le__(self, other: Any, /) -> bool: ...
+    def __gt__(self, other: Any, /) -> bool: ...
+    def __ge__(self, other: Any, /) -> bool: ...
+
+NumberT = TypeVar("NumberT", bound=NumericValue)
+ValueT = TypeVar("ValueT")
+PropertyT = TypeVar("PropertyT", bound=ItemProperty)
+UpgradeT = TypeVar("UpgradeT", bound="Upgrade")
+
+class ItemProperties(dict[ModifierIdentifier, ItemProperty]):
+    def get(self, key: ModifierIdentifier | type[PropertyT], default: Any = None) -> Any:
+        if isinstance(key, type):
+            for prop in self.values():
+                if isinstance(prop, key):
+                    return prop
+            return default
+        
+        return super().get(key, default)
+
+@dataclass(slots=True)
+class InstructionResult:
+    target: str
+    value: Any = None
+    applied: bool = False
+    reason: Optional[str] = None
+
+
+class Instruction(Generic[UpgradeT, ValueT]):
+    """
+    Declarative rule that fills one upgrade field from one or more item properties.
+
+    Each instruction knows:
+    - which upgrade attribute it controls
+    - how to read a candidate value from ItemProperties
+    - how to validate the candidate value
+    """
+
+    def __init__(
+        self,
+        identifier: ModifierIdentifierSpec,
+        target: str,
+        value_getter: Callable[[ItemProperties, UpgradeT], ValueT | None],
+    ) -> None:
+        self.identifier = identifier
+        self.target = target
+        self.value_getter = value_getter
+
+    def get_value(self, properties: ItemProperties, upgrade: UpgradeT) -> ValueT | None:
+        return self.value_getter(properties, upgrade)
+
+    def evaluate(self, value: ValueT | None) -> bool:
+        return value is not None
+
+    def apply(self, upgrade: UpgradeT, properties: ItemProperties) -> InstructionResult:
+        value = self.get_value(properties, upgrade)
+        if not self.evaluate(value):
+            return InstructionResult(
+                target=self.target,
+                value=value,
+                applied=False,
+                reason="candidate value did not satisfy the instruction",
+            )
+
+        setattr(upgrade, self.target, value)
+        return InstructionResult(target=self.target, value=value, applied=True)
+
+class RangeInstruction(Instruction[UpgradeT, NumberT]):
+    def __init__(
+        self,
+        identifier: ModifierIdentifierSpec,
+        target: str,
+        min_value: NumberT,
+        max_value: NumberT,
+        value_getter: Callable[[ItemProperties, UpgradeT], NumberT | None],
+    ) -> None:
+        super().__init__(identifier, target, value_getter)
+        self.min_value = min_value
+        self.max_value = max_value
+
+    @property
+    def range(self) -> tuple[NumberT, NumberT]:
+        return self.min_value, self.max_value
+
+    def evaluate(self, value: NumberT | None) -> bool:
+        return value is not None and self.min_value <= value <= self.max_value
+
+class FixedValueInstruction(Instruction[UpgradeT, ValueT]):
+    def __init__(
+        self,
+        identifier: ModifierIdentifierSpec,
+        target: str,
+        fixed_value: ValueT,
+        value_getter: Callable[[ItemProperties, UpgradeT], ValueT | None],
+    ) -> None:
+        super().__init__(identifier, target, value_getter)
+        self.fixed_value = fixed_value
+
+    def evaluate(self, value: ValueT | None) -> bool:
+        return value == self.fixed_value
+
+def property_value(
+    property_type: type[PropertyT],
+    selector: Callable[[PropertyT], ValueT | None],
+) -> Callable[[ItemProperties, UpgradeT], ValueT | None]: # type: ignore
+    """Create a getter that reads a value from the first matching ItemProperty."""
+
+    def getter(properties: ItemProperties, _: UpgradeT) -> ValueT | None:
+        prop = properties.get(property_type)
+        if prop is None:
+            return None
+        return selector(prop)
+
+    return getter
+
+def ranged(
+    identifier: ModifierIdentifierSpec,
+    target: str,
+    min_value: NumberT,
+    max_value: NumberT,
+    value_getter: Callable[[ItemProperties, UpgradeT], NumberT | None],
+) -> RangeInstruction[UpgradeT, NumberT]:
+    return RangeInstruction(identifier, target, min_value, max_value, value_getter)
+
+def fixed(
+    identifier: ModifierIdentifierSpec,
+    target: str,
+    fixed_value: ValueT,
+    value_getter: Callable[[ItemProperties, UpgradeT], ValueT | None],
+) -> FixedValueInstruction[UpgradeT, ValueT]:
+    return FixedValueInstruction(identifier, target, fixed_value, value_getter)
+
+def _humanize_identifier(name: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", " ", name).strip()
 
 def _get_property_factory():
     from Py4GWCoreLib.item_mods_src.upgrade_parser import get_property_factory
     return get_property_factory()
 
-
-def _humanize_identifier(name: str) -> str:
-    return re.sub(r"(?<!^)(?=[A-Z])", " ", name).strip()
-
-PERSISTENT = True
-
-class ModifierType(IntEnum):
-    None_ = 0
-    Arg1 = 1
-    Arg2 = 2
-    Fixed = 3
-    
-class ModifierRange:
-    def __init__(self, modifier_identifier : ModifierIdentifier, modifier_type : ModifierType, min_value: int, max_value: int):
-        self.modifierIdentifier = modifier_identifier
-        self.min_value = min_value
-        self.max_value = max_value
-        self.modifier_type = modifier_type
-        
 @dataclass(eq=False)
 class Upgrade:
     """
@@ -54,18 +165,17 @@ class Upgrade:
     _registry: ClassVar[dict[str, type["Upgrade"]]] = {}
     mod_type: ClassVar[ItemUpgradeType] = ItemUpgradeType.Unknown
     id: ClassVar[ItemUpgrade] = ItemUpgrade.Unknown
-    property_identifiers: ClassVar[list[ModifierIdentifierSpec]] = []
-    max_modifier_values: ClassVar[dict[ModifierIdentifier, tuple[int, int]]] = {}
-    encoded_name: ClassVar[bytes] = bytes()
-    descriptions: ClassVar[dict[ServerLanguage, str]] = {}
-
+    
+    properties: ItemProperties = field(default_factory=ItemProperties)
+    
     rarity: Rarity = field(init=False, default=Rarity.Blue, repr=False, compare=False)
     upgrade_id: ItemUpgradeId = field(init=False, default=ItemUpgradeId.Unknown, repr=False, compare=False)
-    properties: dict[ModifierIdentifier, ItemProperty] = field(init=False, default_factory=dict, repr=False, compare=False)
     modifier: Optional[DecodedModifier] = field(init=False, default=None, repr=False, compare=False)
     is_inherent: bool = field(init=False, default=False, repr=False, compare=False)
     language: ServerLanguage = field(init=False, repr=False, compare=False)
-    _property_values: dict[str, Any] = field(init=False, default_factory=dict, repr=False, compare=False)
+    
+    upgrade_info: ClassVar[tuple[Instruction["Upgrade", Any], ...]] = ()
+
     __encoded_name: GWStringEncoded = field(init=False, repr=False, compare=False)
     __encoded_description: GWStringEncoded = field(init=False, repr=False, compare=False)
 
@@ -79,21 +189,27 @@ class Upgrade:
         object.__setattr__(self, "rarity", getattr(type(self), "rarity", Rarity.Blue))
         object.__setattr__(self, "upgrade_id", ItemUpgradeId.Unknown)
         object.__setattr__(self, "modifier", None)
-        object.__setattr__(self, "properties", {})
-        object.__setattr__(self, "_property_values", {name: getattr(self, name) for name in self._get_serializable_property_names()})
-        self._rebuild_properties_from_values()
+
+        cls = type(self)
+        for field_info in fields(self):
+            if not field_info.init:
+                continue
+            field_value = getattr(cls, field_info.name, MISSING)
+            if field_value is not MISSING:
+                object.__setattr__(self, field_info.name, field_value)
+        
         self._refresh_encoded_strings()
 
     def __setattr__(self, name: str, value: Any) -> None:
-        if name in type(self)._get_serializable_property_names() and "_property_values" in self.__dict__:
+        upgrade_info_targets = {instruction.target for instruction in self.upgrade_info}
+        if name in type(self)._get_serializable_property_names() or name in upgrade_info_targets:
             object.__setattr__(self, name, value)
-            self._property_values[name] = value
-            self._rebuild_properties_from_values()
             self._refresh_encoded_strings()
             return
 
         object.__setattr__(self, name, value)
-        
+
+    #region Upgrade Composition from Modifiers
     @classmethod
     def _pre_compose(cls, upgrade: "Upgrade", mod: DecodedModifier, all_modifiers: list[DecodedModifier], remaining_modifiers: list[DecodedModifier]) -> None:
         return None
@@ -102,62 +218,101 @@ class Upgrade:
     def _post_compose(cls, upgrade: "Upgrade", mod: DecodedModifier, all_modifiers: list[DecodedModifier], remaining_modifiers: list[DecodedModifier]) -> None:
         return None
 
+    @classmethod
+    def _can_compose(cls, mod: DecodedModifier, all_modifiers: list[DecodedModifier], remaining_modifiers: list[DecodedModifier]) -> bool:
+        return True
+        
+    @classmethod
+    def compose_from_modifiers(cls, mod : DecodedModifier, remaining_modifiers: list[DecodedModifier], all_modifiers: list[DecodedModifier], rarity: Rarity = Rarity.Blue) -> Optional["Upgrade"]:        
+        if not cls._can_compose(mod, all_modifiers, remaining_modifiers):
+            return None
+
+        upgrade = cls()
+        upgrade.upgrade_id = mod.upgrade_id
+        upgrade.rarity = rarity
+        upgrade.modifier = mod
+
+        cls._pre_compose(upgrade, mod, all_modifiers, remaining_modifiers)
+
+        property_factory = _get_property_factory()
+        matched_modifiers = cls._match_property_modifiers(remaining_modifiers)
+        if not cls.upgrade_info or len(cls.upgrade_info) == 0:
+            upgrade._refresh_encoded_strings()
+            return upgrade
+        
+        if matched_modifiers is None:
+            return None
+
+        for prop_key, prop_mod in matched_modifiers:
+            prop = property_factory.get(prop_mod.identifier, lambda m, _, rarity: ItemProperty(modifier=m, rarity=rarity))(prop_mod, remaining_modifiers, rarity)
+            upgrade.properties[prop_key] = prop
+
+            matched_instructions = [instruction for instruction in cls.upgrade_info if cls._get_property_identifier_key(instruction.identifier) == prop_key]
+            modifier_applied = False
+            for instruction in matched_instructions:
+                result = instruction.apply(upgrade, upgrade.properties)
+                if not result.applied:
+                    return None
+                modifier_applied = True
+
+            if modifier_applied and prop_mod in remaining_modifiers:
+                remaining_modifiers.remove(prop_mod)
+
+        cls._post_compose(upgrade, mod, all_modifiers, remaining_modifiers)
+        upgrade._refresh_encoded_strings()
+        return upgrade
+   
     @staticmethod
     def _normalize_property_identifier_spec(identifier_spec: ModifierIdentifierSpec) -> tuple[ModifierIdentifier, ...]:
         if isinstance(identifier_spec, tuple):
             return identifier_spec
         return (identifier_spec,)
-
+    
     @classmethod
     def _get_property_identifier_key(cls, identifier_spec: ModifierIdentifierSpec) -> ModifierIdentifier:
         return cls._normalize_property_identifier_spec(identifier_spec)[0]
 
     @classmethod
-    def _format_property_identifier_spec(cls, identifier_spec: ModifierIdentifierSpec) -> str:
-        identifiers = cls._normalize_property_identifier_spec(identifier_spec)
-        return " OR ".join(identifier.name for identifier in identifiers)
+    def _match_property_modifiers(cls, modifiers: list[DecodedModifier]) -> Optional[list[tuple[ModifierIdentifier, DecodedModifier]]]:
+        used_modifiers: list[DecodedModifier] = []
+        matched_by_key: dict[ModifierIdentifier, DecodedModifier] = {}
+
+        if cls.upgrade_info:
+            for inst in cls.upgrade_info:
+                prop_key = cls._get_property_identifier_key(inst.identifier)
+                prop_mod = matched_by_key.get(prop_key)
+                if prop_mod is None:
+                    identifier_options = cls._normalize_property_identifier_spec(inst.identifier)
+                    prop_mod = next((m for m in modifiers if m not in used_modifiers and m.identifier in identifier_options), None)
+                    if prop_mod is not None:
+                        matched_by_key[prop_key] = prop_mod
+                        used_modifiers.append(prop_mod)
+                        
+                if prop_mod is None:
+                    return None
+
+        return list(matched_by_key.items())
+    #endregion Upgrade Composition from Modifiers
+    
+    @classmethod
+    def has_id(cls, upgrade_id: ItemUpgradeId) -> bool:
+        return cls.id.has_id(upgrade_id)
 
     @classmethod
-    def _match_property_modifiers(cls, modifiers: list[DecodedModifier]) -> Optional[list[tuple[ModifierIdentifier, DecodedModifier]]]:
-        matched_modifiers: list[tuple[ModifierIdentifier, DecodedModifier]] = []
-        used_modifiers: list[DecodedModifier] = []
+    def get_specificity_score(cls) -> tuple[int, int]:
+        fixed_instruction_count = sum(
+            1
+            for instruction in cls.upgrade_info
+            if isinstance(instruction, FixedValueInstruction)
+        )
+        inheritance_depth = len(cls.mro())
+        return fixed_instruction_count, inheritance_depth
 
-        for identifier_spec in cls.property_identifiers:
-            identifier_options = cls._normalize_property_identifier_spec(identifier_spec)
-            prop_mod = next((m for m in modifiers if m not in used_modifiers and m.identifier in identifier_options), None)
-            if prop_mod is None:
-                return None
-
-            matched_modifiers.append((cls._get_property_identifier_key(identifier_spec), prop_mod))
-            used_modifiers.append(prop_mod)
-
-        return matched_modifiers
-
-    def _get_property_by_spec(self, identifier_spec: ModifierIdentifierSpec) -> Optional[ItemProperty]:
-        for identifier in self._normalize_property_identifier_spec(identifier_spec):
-            prop = self.properties.get(identifier)
-            if prop is not None:
-                return prop
-        return None
-
-    def _get_upgrade_property(self, identifier_spec: ModifierIdentifierSpec) -> Optional[ItemProperty]:
-        return self._get_property_by_spec(identifier_spec)
-
-    def _get_property_value(self, identifier_spec: ModifierIdentifierSpec, attr_name: str, default):
-        if attr_name in self._property_values:
-            return self._property_values[attr_name]
-
-        prop = self._get_property_by_spec(identifier_spec)
-        if prop is None:
-            return default
-
-        value = getattr(prop, attr_name, default)
-        self._property_values[attr_name] = value
-        return value
-
+    #region Equality and Matching
     @classmethod
     def _get_serializable_property_names(cls) -> list[str]:
-        return [field_info.name for field_info in fields(cls) if field_info.init]
+        blacklisted_fields = {"properties", "modifier", "language"}        
+        return [field_info.name for field_info in fields(cls) if field_info.init and field_info.name not in blacklisted_fields]
 
     @staticmethod
     def _serialize_value(value: Any) -> Any:
@@ -211,247 +366,6 @@ class Upgrade:
 
         return value
 
-    def _update_property_values_from_property(self, prop: ItemProperty) -> None:
-        if not is_dataclass(prop):
-            return
-
-        for field_info in fields(prop):
-            if field_info.name in {"modifier", "rarity", "upgrade", "upgrade_id"}:
-                continue
-
-            value = getattr(prop, field_info.name)
-            self._property_values[field_info.name] = value
-            if field_info.name in type(self)._get_serializable_property_names():
-                object.__setattr__(self, field_info.name, value)
-
-    def _sync_property_values_from_properties(self) -> None:
-        for prop in self.properties.values():
-            self._update_property_values_from_property(prop)
-
-    def _refresh_encoded_strings(self) -> None:
-        self.__encoded_name = self.create_encoded_name()
-        self.__encoded_description = self.create_encoded_description()
-
-    @classmethod
-    def _infer_property_class(cls, identifier_spec: ModifierIdentifierSpec, rarity: Rarity) -> Optional[type[ItemProperty]]:
-        property_factory = _get_property_factory()
-
-        for identifier in cls._normalize_property_identifier_spec(identifier_spec):
-            synthetic_modifier = cls._create_synthetic_modifier(identifier, 0, 0)
-            property_builder = property_factory.get(identifier, lambda m, _, current_rarity: ItemProperty(modifier=m, rarity=current_rarity))
-            try:
-                return type(property_builder(synthetic_modifier, [synthetic_modifier], rarity))
-            except Exception:
-                continue
-
-        return None
-
-    def _rebuild_properties_from_values(self) -> None:
-        rebuilt_properties: dict[ModifierIdentifier, ItemProperty] = {}
-
-        for identifier_spec in self.property_identifiers:
-            prop_cls = self._infer_property_class(identifier_spec, self.rarity)
-            if prop_cls is None or not is_dataclass(prop_cls):
-                continue
-
-            kwargs: dict[str, Any] = {
-                "modifier": self._create_synthetic_modifier(self._get_property_identifier_key(identifier_spec), 0, 0),
-                "rarity": self.rarity,
-            }
-
-            can_create = True
-            for field_info in fields(prop_cls):
-                if field_info.name in kwargs or field_info.name in {"upgrade", "upgrade_id"}:
-                    continue
-
-                if field_info.name in self._property_values:
-                    kwargs[field_info.name] = self._property_values[field_info.name]
-                    continue
-
-                if field_info.default is not MISSING or field_info.default_factory is not MISSING:
-                    continue
-
-                can_create = False
-                break
-
-            if not can_create:
-                continue
-
-            try:
-                rebuilt_properties[self._get_property_identifier_key(identifier_spec)] = prop_cls(**kwargs)
-            except Exception:
-                continue
-
-        self.properties = rebuilt_properties
-    
-    @classmethod
-    def compose_from_modifiers(cls, mod : DecodedModifier, remaining_modifiers: list[DecodedModifier], all_modifiers: list[DecodedModifier], rarity: Rarity = Rarity.Blue) -> Optional["Upgrade"]:        
-        upgrade = cls()
-        upgrade.properties = {}
-        upgrade._property_values = {}
-        upgrade.upgrade_id = mod.upgrade_id
-        upgrade.rarity = rarity
-        upgrade.modifier = mod
-
-        cls._pre_compose(upgrade, mod, all_modifiers, remaining_modifiers)
-
-        property_factory = _get_property_factory()
-        matched_modifiers = cls._match_property_modifiers(remaining_modifiers)
-        if matched_modifiers is None:
-            for identifier_spec in upgrade.property_identifiers:
-                identifier_options = cls._normalize_property_identifier_spec(identifier_spec)
-                if not any(m.identifier in identifier_options for m in remaining_modifiers):
-                    Py4GW.Console.Log("ItemHandling", f"Missing modifier for property {cls._format_property_identifier_spec(identifier_spec)} in upgrade {upgrade.__class__.__name__}. Upgrade composition failed.")
-                    return None
-            return None
-
-        for prop_key, prop_mod in matched_modifiers:
-            prop = property_factory.get(prop_mod.identifier, lambda m, _, rarity: ItemProperty(modifier=m, rarity=rarity))(prop_mod, remaining_modifiers, rarity)
-            upgrade.properties[prop_key] = prop
-
-        cls._post_compose(upgrade, mod, all_modifiers, remaining_modifiers)
-        upgrade._sync_property_values_from_properties()
-        upgrade._refresh_encoded_strings()
-        return upgrade
-
-    @classmethod
-    def has_id(cls, upgrade_id: ItemUpgradeId) -> bool:
-        return cls.id.has_id(upgrade_id)
-
-    @classmethod
-    def _get_max_modifier_args(cls, identifier: ModifierIdentifier) -> Optional[tuple[int, int]]:
-        args = cls.max_modifier_values.get(identifier)
-        if args is not None:
-            return args
-
-        modifier_range_prop = getattr(cls, "modifier_range", None)
-        modifier_range = cast(Optional[ModifierRange], modifier_range_prop) if isinstance(modifier_range_prop, ModifierRange) else None
-        if modifier_range and modifier_range.modifierIdentifier == identifier:
-            arg1 = 0
-            arg2 = 0
-
-            match modifier_range.modifier_type:
-                case ModifierType.Arg1:
-                    arg1 = modifier_range.max_value
-                case ModifierType.Arg2 | ModifierType.Fixed:
-                    arg2 = modifier_range.max_value
-                case ModifierType.None_:
-                    return None
-
-            return arg1, arg2
-
-        return None
-
-    @classmethod
-    def _create_synthetic_modifier(cls, identifier: ModifierIdentifier, arg1: int, arg2: int) -> DecodedModifier:
-        return DecodedModifier(
-            modifier=cast(ItemModifier, None),
-            raw_identifier=0,
-            identifier=identifier,
-            param=cast(ItemModifierParam, 0),
-            arg1=arg1,
-            arg2=arg2,
-            arg=(arg1 << 8) | arg2,
-            raw_bits=0,
-            upgrade_id=ItemUpgradeId.Unknown,
-            flags=0,
-        )
-
-    @classmethod
-    def _create_max_properties(cls, rarity: Rarity = Rarity.Blue) -> Optional[dict[ModifierIdentifier, ItemProperty]]:
-        if not cls.property_identifiers:
-            return {}
-        modifiers: list[DecodedModifier] = []
-        created_modifier_ids: set[ModifierIdentifier] = set()
-        property_identifier_options = {
-            identifier
-            for identifier_spec in cls.property_identifiers
-            for identifier in cls._normalize_property_identifier_spec(identifier_spec)
-        }
-
-        for identifier_spec in cls.property_identifiers:
-            resolved_identifier: Optional[ModifierIdentifier] = None
-            resolved_args: Optional[tuple[int, int]] = None
-
-            for identifier in cls._normalize_property_identifier_spec(identifier_spec):
-                args = cls._get_max_modifier_args(identifier)
-                if args is not None:
-                    resolved_identifier = identifier
-                    resolved_args = args
-                    break
-
-            if resolved_identifier is None or resolved_args is None:
-                return None
-
-            if resolved_identifier not in created_modifier_ids:
-                modifiers.append(cls._create_synthetic_modifier(resolved_identifier, resolved_args[0], resolved_args[1]))
-                created_modifier_ids.add(resolved_identifier)
-
-        for identifier, args in cls.max_modifier_values.items():
-            if identifier in created_modifier_ids or identifier in property_identifier_options:
-                continue
-
-            modifiers.append(cls._create_synthetic_modifier(identifier, args[0], args[1]))
-            created_modifier_ids.add(identifier)
-
-        property_factory = _get_property_factory()
-        properties: dict[ModifierIdentifier, ItemProperty] = {}
-
-        for identifier_spec in cls.property_identifiers:
-            prop_key = cls._get_property_identifier_key(identifier_spec)
-            identifier_options = cls._normalize_property_identifier_spec(identifier_spec)
-            prop_mod = next((m for m in modifiers if m.identifier in identifier_options), None)
-            if prop_mod is None:
-                return None
-
-            prop = property_factory.get(prop_mod.identifier, lambda m, _, rarity: ItemProperty(modifier=m, rarity=rarity))(prop_mod, modifiers, rarity)
-            properties[prop_key] = prop
-
-        return properties
-
-    @classmethod
-    def get_max_description_encoded(cls, rarity: Rarity = Rarity.Blue) -> Optional[GWStringEncoded]:
-        properties = cls._create_max_properties(rarity)
-        if properties is None:
-            return None
-
-        if not properties:
-            fallback = cls.descriptions.get(ServerLanguage.English)
-            if fallback:
-                return GWStringEncoded(bytes(), fallback)
-            return None
-
-        parts = [prop.encoded_description for prop in properties.values() if prop.encoded_description]
-        return GWEncoded.combine_encoded_strings(parts, f"no max description ({cls.__name__})")
-
-    @classmethod
-    def get_max_description_plain(cls, rarity: Rarity = Rarity.Blue) -> Optional[str]:
-        encoded = cls.get_max_description_encoded(rarity)
-        if encoded is None:
-            return None
-
-        return encoded.bonuses_only or encoded.plain or encoded.full or None
-    
-    def get_text_color(self, name : bool = False) -> bytes:
-        match self.rarity:
-            case Rarity.Blue | Rarity.White:
-                return GWEncoded.ITEM_ENHANCE if name else GWEncoded.ITEM_BONUS
-            
-            case Rarity.Purple:
-                return GWEncoded.ITEM_UNCOMMON
-            
-            case Rarity.Gold:
-                return GWEncoded.ITEM_RARE
-            
-            case Rarity.Green:
-                return GWEncoded.ITEM_UNIQUE
-            
-    def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.encoded_name, f"no encoded name ({self.__class__.__name__})")
-    
-    def create_encoded_description(self) -> GWStringEncoded:
-        return GWStringEncoded(bytes(), f"no encoded description ({self.__class__.__name__})")
-
     def _comparison_data(self) -> tuple[str, tuple[tuple[str, Any], ...]]:
         comparison_values = {
             property_name: self._normalize_comparison_value(getattr(self, property_name))
@@ -467,7 +381,9 @@ class Upgrade:
 
     def __eq__(self, other: object) -> bool:
         return self.equals(other)
-
+    #endregion Equality and Matching
+    
+    #region Serialization
     def to_dict(self) -> dict[str, Any]:
         values = {
             property_name: self._serialize_value(getattr(self, property_name))
@@ -496,7 +412,46 @@ class Upgrade:
             str(key): cls._deserialize_value(value)
             for key, value in raw_values.items()
         }
-        return upgrade_cls(**values)
+
+        upgrade = upgrade_cls()
+        valid_property_names = set(upgrade_cls._get_serializable_property_names())
+        for key, value in values.items():
+            if key in valid_property_names:
+                setattr(upgrade, key, value)
+
+        return upgrade
+    #endregion Serialization
+    
+    #region Encoded String Generation
+    def get_text_color(self, name : bool = False) -> bytes:
+        match self.rarity:
+            case Rarity.Blue | Rarity.White:
+                return GWEncoded.ITEM_ENHANCE if name else GWEncoded.ITEM_BONUS
+            
+            case Rarity.Purple:
+                return GWEncoded.ITEM_UNCOMMON
+            
+            case Rarity.Gold:
+                return GWEncoded.ITEM_RARE
+            
+            case Rarity.Green:
+                return GWEncoded.ITEM_UNIQUE
+            
+    def create_upgrade_name(self, item_type: ItemType) -> GWStringEncoded:
+        encoded_name = self.create_encoded_name()
+        return encoded_name
+    
+    def create_encoded_name(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes(), f"{_humanize_identifier(self.__class__.__name__)} (no encoded name)")
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes(), f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)")
+    
+    def _refresh_encoded_strings(self) -> None:        
+        self.__encoded_name = self.create_encoded_name()
+        self.__encoded_description = self.create_encoded_description()
+
+    #endregion Encoded String Generation
     
     @property
     def name(self) -> str:
@@ -531,875 +486,3014 @@ class Upgrade:
         
         return None
     
+    @property
+    def is_maxed(self) -> bool:
+        for instruction in self.upgrade_info:
+            if isinstance(instruction, RangeInstruction):
+                value = getattr(self, instruction.target)
+                if value < instruction.max_value:
+                    return False
+                
+        return True
+    
     @classmethod
     def get_static_name(cls, rarity : Rarity = Rarity.Blue) -> str: 
         temp_instance = cls()
         temp_instance.rarity = rarity
         temp_instance.__encoded_name = temp_instance.create_encoded_name()
         
-        return temp_instance.name_plain           
-    
-    @property
-    def is_maxed(self) -> bool:
-        return True
-    
+        return temp_instance.name_plain
+
 @dataclass(eq=False)
 class UnknownUpgrade(Upgrade):
     mod_type = ItemUpgradeType.Unknown
     id = ItemUpgrade.Unknown
-    property_identifiers = []
+    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes(), f"{_humanize_identifier(self.modifier.upgrade_id.name) if self.modifier else 'Unknown Upgrade'} (ID: {self.modifier.upgrade_id.value if self.modifier else 'N/A'})")
+    
+    def create_encoded_name(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes(), f"{_humanize_identifier(self.modifier.upgrade_id.name) if self.modifier else 'Unknown Upgrade'}")
+
     
 #region Weapon Upgrades
 @dataclass(eq=False)
 class WeaponUpgrade(Upgrade):
     target_item_type: ItemType = field(init=False, default=ItemType.Unknown, repr=False, compare=False)
-    modifier_range: ClassVar[Optional[ModifierRange]] = None
 
     @classmethod
     def _pre_compose(cls, upgrade: "Upgrade", mod: DecodedModifier, all_modifiers: list[DecodedModifier], remaining_modifiers: list[DecodedModifier]) -> None:
-        weapon_upgrade = cast("WeaponUpgrade", upgrade)
-        weapon_upgrade.target_item_type = cls.id.get_item_type(weapon_upgrade.upgrade_id)
-
-    def create_encoded_description(self) -> GWStringEncoded:
-        if not self.properties:
-            return super().create_encoded_description()
-        parts = [prop.encoded_description for prop in self.properties.values() if prop.encoded_description]
-        return GWEncoded.combine_encoded_strings(parts, "no encoded description")
-
-    @property
-    def is_maxed(self) -> bool:
-        if not self.properties or not self.modifier_range:
-            return True
-        
-        prop = self._get_upgrade_property(self.modifier_range.modifierIdentifier)
-    
-        if not prop:
-            return False
-        
-        value = prop.modifier.arg1 if self.modifier_range.modifier_type == ModifierType.Arg1 else prop.modifier.arg2
-        if value < self.modifier_range.min_value or value > self.modifier_range.max_value:
-            return False
-    
-        return True
-        
+        weapon_upgrade = cast(WeaponUpgrade, upgrade)
+        weapon_upgrade.target_item_type = cls.id.get_item_type(weapon_upgrade.upgrade_id)      
+             
 #region Prefixes
 
 @dataclass(eq=False)
 class WeaponPrefix(WeaponUpgrade):
     mod_type = ItemUpgradeType.Prefix
+
+    def create_upgrade_name(self, item_type: ItemType) -> GWStringEncoded:
+        encoded_upgrade_component = GWEncoded.WEAPON_PREFIXES.get(item_type) or bytes()
+        if not encoded_upgrade_component:
+            return self.create_encoded_name()
+
+        encoded_name = self.create_encoded_name()
+        color_bytes = self.get_text_color(True)
+        suffix = encoded_name.encoded[len(color_bytes):] if encoded_name.encoded.startswith(color_bytes) else encoded_name.encoded
+        return GWStringEncoded(
+            bytes([*color_bytes, *encoded_upgrade_component, *suffix]),
+            encoded_name.fallback,
+            encoded_name.placeholder_bytes,
+            encoded_name.placeholder_replacement,
+        )
     
 @dataclass(eq=False)
-class AdeptUpgrade(WeaponPrefix):
-    chance: int = 0
-
-    id = ItemUpgrade.Adept
-    property_identifiers = [
-        ModifierIdentifier.HalvesCastingTimeItemAttribute,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesCastingTimeItemAttribute, ModifierType.Arg1, 10, 20)
+class IncreaseConditionDurationUpgrade(WeaponPrefix):
+    condition: Ailment | None = None
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        if self.condition is None:
+            return super().create_encoded_description()
+        
+        encoded = GWEncoded.CONDITION_INCREASE_BYTES.get(self.condition)
+        fallback = f"Lengthens {self.condition.name.replace('_', ' ')} duration on foes by 33%"
+        
+        if encoded:
+            return GWStringEncoded(bytes([*self.get_text_color(), *encoded, *GWEncoded._dull_parenthesized(GWEncoded.STACKING_BYTES, "(Stacking)")]), fallback)
+        
+        return GWStringEncoded(bytes(), fallback)
+
+@dataclass(eq=False)
+class DamageTypeUpgrade(WeaponPrefix):
+    damage_type: DamageType | None = None
+    
+    def create_encoded_description(self) -> GWStringEncoded:
+        if self.damage_type is None:
+            return super().create_encoded_description()
+        
+        damage_bytes = GWEncoded.DAMAGE_TYPE_BYTES.get(self.damage_type)
+        if damage_bytes:            
+            return GWStringEncoded(bytes([*GWEncoded.ITEM_BASIC, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x4C, 0xA, 0x1, 0x0, 0xB, 0x1, *damage_bytes, 0x1, 0x0]), f"{self.damage_type.name} Dmg")
+        
+        return GWStringEncoded(bytes(), f"{self.damage_type.name} Dmg")
+
+@dataclass
+class AdeptUpgrade(WeaponPrefix):
+    id: ClassVar[ItemUpgrade] = ItemUpgrade.Adept
+    chance: int = 20
+
+    upgrade_info = (
+        ranged(
+            identifier= ModifierIdentifier.HalvesCastingTimeItemAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+    )
+    
+    def create_upgrade_name(self, item_type):        
+        encoded_upgrade_component = (GWEncoded.WEAPON_PREFIXES.get(item_type) if self.mod_type == ItemUpgradeType.Prefix else GWEncoded.WEAPON_SUFFIXES.get(item_type)) or bytes()
+        return GWStringEncoded(bytes([*self.get_text_color(True), *encoded_upgrade_component, 0x1, 0x81, 0x94, 0x5D, 0x1, 0x0]), f"Adept") if encoded_upgrade_component else self.create_encoded_name()
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x1, 0x81, 0x94, 0x5D, 0x1, 0x0]), f"Adept")
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.HALVES_CASTING_ITEM_ATTRIBUTE_BYTES]), "Halves casting time on spells of item's attribute"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, "no encoded description")
+
 @dataclass(eq=False)
-class BarbedUpgrade(WeaponPrefix):
-    condition: Ailment | None = None
-
+class BarbedUpgrade(IncreaseConditionDurationUpgrade):
     id = ItemUpgrade.Barbed
-    property_identifiers = [
-        ModifierIdentifier.IncreaseConditionDuration,
-    ]
+    condition = Ailment.Bleeding
 
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.IncreaseConditionDuration,
+            target="condition",
+            fixed_value=Ailment.Bleeding,
+            value_getter=property_value(
+                IncreaseConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+    )
+    
+    def create_upgrade_name(self, item_type):
+        encoded_upgrade_component = (GWEncoded.WEAPON_PREFIXES.get(item_type) if self.mod_type == ItemUpgradeType.Prefix else GWEncoded.WEAPON_SUFFIXES.get(item_type)) or bytes()
+        return GWStringEncoded(bytes([*self.get_text_color(True), *encoded_upgrade_component, 0x69, 0xA, 0x1, 0x0]), f"Barbed") if encoded_upgrade_component else self.create_encoded_name()
     
     def create_encoded_name(self) -> GWStringEncoded:
          return GWStringEncoded(self.get_text_color(True) + bytes([0x69, 0xA, 0x1, 0x0]), f"Barbed")
-    
+
 @dataclass(eq=False)
-class CripplingUpgrade(WeaponPrefix):
-    condition: Ailment | None = None
-
+class CripplingUpgrade(IncreaseConditionDurationUpgrade):
     id = ItemUpgrade.Crippling
-    property_identifiers = [
-        ModifierIdentifier.IncreaseConditionDuration,
-    ]
+    condition = Ailment.Crippled
 
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.IncreaseConditionDuration,
+            target="condition",
+            fixed_value=Ailment.Crippled,
+            value_getter=property_value(
+                IncreaseConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+    )
+
+    def create_upgrade_name(self, item_type):
+        encoded_upgrade_component = (GWEncoded.WEAPON_PREFIXES.get(item_type) if self.mod_type == ItemUpgradeType.Prefix else GWEncoded.WEAPON_SUFFIXES.get(item_type)) or bytes()
+        return GWStringEncoded(bytes([*self.get_text_color(True), *encoded_upgrade_component, 0x6A, 0xA, 0x1, 0x0]), f"Crippling") if encoded_upgrade_component else self.create_encoded_name()
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x6A, 0xA, 0x1, 0x0]), f"Crippling")
         
 @dataclass(eq=False)
-class CruelUpgrade(WeaponPrefix):
-    condition: Ailment | None = None
-
+class CruelUpgrade(IncreaseConditionDurationUpgrade):
     id = ItemUpgrade.Cruel
-    property_identifiers = [
-        ModifierIdentifier.IncreaseConditionDuration,
-    ]
+    condition = Ailment.Deep_Wound
 
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.IncreaseConditionDuration,
+            target="condition",
+            fixed_value=Ailment.Deep_Wound,
+            value_getter=property_value(
+                IncreaseConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+    )
+
+    
+    def create_upgrade_name(self, item_type):
+        encoded_upgrade_component = (GWEncoded.WEAPON_PREFIXES.get(item_type) if self.mod_type == ItemUpgradeType.Prefix else GWEncoded.WEAPON_SUFFIXES.get(item_type)) or bytes()
+        return GWStringEncoded(bytes([*self.get_text_color(True), *encoded_upgrade_component, 0x6B, 0xA, 0x1, 0x0]), f"Cruel") if encoded_upgrade_component else self.create_encoded_name()
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x6B, 0xA, 0x1, 0x0]), f"Cruel")
 
+    
 @dataclass(eq=False)
 class DefensiveUpgrade(WeaponPrefix):
-    armor: int = 0
-
     id = ItemUpgrade.Defensive
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlus,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlus, ModifierType.Arg2, 1, 5)
-
+    armor: int = 5
+    
+    upgrade_info = (
+        ranged(
+            identifier= ModifierIdentifier.ArmorPlus,
+            target="armor",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                ArmorPlus,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x6D, 0xA, 0x1, 0x0]), f"Defensive")
     
-@dataclass(eq=False)
-class EbonUpgrade(WeaponPrefix):
-    damage_type: DamageType | None = None
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor")
 
+@dataclass(eq=False)
+class EbonUpgrade(DamageTypeUpgrade):
     id = ItemUpgrade.Ebon
-    property_identifiers = [
-        ModifierIdentifier.DamageTypeProperty,
-    ]
+    damage_type = DamageType.Earth
 
-    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamageTypeProperty,
+            target="damage_type",
+            fixed_value=DamageType.Earth,
+            value_getter=property_value(
+                DamageTypeProperty,
+                lambda prop: prop.damage_type,
+            ),
+        ),
+    )
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0xD5, 0x8, 0x1, 0x0]), f"Ebon")
-    
+        return GWStringEncoded(self.get_text_color(True) + bytes([0xD5, 0x8, 0x1, 0x0]), "Ebon")
+
 @dataclass(eq=False)
-class FieryUpgrade(WeaponPrefix):
-    damage_type: DamageType | None = None
-
+class FieryUpgrade(DamageTypeUpgrade):
     id = ItemUpgrade.Fiery
-    property_identifiers = [
-        ModifierIdentifier.DamageTypeProperty,
-    ]
+    damage_type = DamageType.Fire
 
-    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamageTypeProperty,
+            target="damage_type",
+            fixed_value=DamageType.Fire,
+            value_getter=property_value(
+                DamageTypeProperty,
+                lambda prop: prop.damage_type,
+            ),
+        ),
+    )
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0xD7, 0x8, 0x1, 0x0]), f"Fiery")
-    
+        return GWStringEncoded(self.get_text_color(True) + bytes([0xD7, 0x8, 0x1, 0x0]), "Fiery")
+
 @dataclass(eq=False)
 class FuriousUpgrade(WeaponPrefix):
-    chance: int = 0
-
     id = ItemUpgrade.Furious
-    property_identifiers = [
-        ModifierIdentifier.Furious,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.Furious, ModifierType.Arg2, 2, 10)
-    
-    
+    chance: int = 10
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.Furious,
+            target="chance",
+            min_value=2,
+            max_value=10,
+            value_getter=property_value(
+                Furious,
+                lambda prop: prop.chance,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.DOUBLE_ADRENALINE_BYTES]), "Double Adrenaline on hit"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0x6F, 0xA, 0x1, 0x0]), f"Furious")
-    
+        return GWStringEncoded(self.get_text_color(True) + bytes([0x6F, 0xA, 0x1, 0x0]), "Furious")
+
 @dataclass(eq=False)
 class HaleUpgrade(WeaponPrefix):
-    health: int = 0
-
     id = ItemUpgrade.Hale
-    property_identifiers = [
-        ModifierIdentifier.HealthPlus,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HealthPlus, ModifierType.Arg1, 1, 30)
+    health: int = 30
 
-    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HealthPlus,
+            target="health",
+            min_value=10,
+            max_value=30,
+            value_getter=property_value(
+                HealthPlus,
+                lambda prop: prop.health,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.HEALTH_BYTES, self.health, "Health")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0x70, 0xA, 0x1, 0x0]), f"Hale")
-    
-@dataclass(eq=False)
-class HeavyUpgrade(WeaponPrefix):
-    condition: Ailment | None = None
+        return GWStringEncoded(self.get_text_color(True) + bytes([0x70, 0xA, 0x1, 0x0]), "Hale")
 
+@dataclass(eq=False)
+class HeavyUpgrade(IncreaseConditionDurationUpgrade):
     id = ItemUpgrade.Heavy
-    property_identifiers = [
-        ModifierIdentifier.IncreaseConditionDuration,
-    ]
+    condition = Ailment.Weakness
 
-    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.IncreaseConditionDuration,
+            target="condition",
+            fixed_value=Ailment.Weakness,
+            value_getter=property_value(
+                IncreaseConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+    )
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0x72, 0xA, 0x1, 0x0]), f"Heavy")
-    
+        return GWStringEncoded(self.get_text_color(True) + bytes([0x72, 0xA, 0x1, 0x0]), "Heavy")
+
 @dataclass(eq=False)
-class IcyUpgrade(WeaponPrefix):
-    damage_type: DamageType | None = None
-
+class IcyUpgrade(DamageTypeUpgrade):
     id = ItemUpgrade.Icy
-    property_identifiers = [
-        ModifierIdentifier.DamageTypeProperty,
-    ]
+    damage_type = DamageType.Cold
 
-    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamageTypeProperty,
+            target="damage_type",
+            fixed_value=DamageType.Cold,
+            value_getter=property_value(
+                DamageTypeProperty,
+                lambda prop: prop.damage_type,
+            ),
+        ),
+    )
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0xD4, 0x8, 0x1, 0x0]), f"Icy")
-    
+        return GWStringEncoded(self.get_text_color(True) + bytes([0xD4, 0x8, 0x1, 0x0]), "Icy")
+
 @dataclass(eq=False)
 class InsightfulUpgrade(WeaponPrefix):
-    energy: int = 0
-
     id = ItemUpgrade.Insightful
-    property_identifiers = [
-        ModifierIdentifier.EnergyPlus,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.EnergyPlus, ModifierType.Arg2, 1, 5)
+    energy: int = 5
 
-    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.EnergyPlus,
+            target="energy",
+            min_value=1,
+            max_value=5,
+            value_getter=property_value(
+                EnergyPlus,
+                lambda prop: prop.energy,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ENERGY_BYTES, self.energy, "Energy")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0x73, 0xA, 0x1, 0x0]), f"Insightful")
-    
-@dataclass(eq=False)
-class PoisonousUpgrade(WeaponPrefix):
-    condition: Ailment | None = None
+        return GWStringEncoded(self.get_text_color(True) + bytes([0x73, 0xA, 0x1, 0x0]), "Insightful")
 
+@dataclass(eq=False)
+class PoisonousUpgrade(IncreaseConditionDurationUpgrade):
     id = ItemUpgrade.Poisonous
-    property_identifiers = [
-        ModifierIdentifier.IncreaseConditionDuration,
-    ]
+    condition = Ailment.Poison
 
-    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.IncreaseConditionDuration,
+            target="condition",
+            fixed_value=Ailment.Poison,
+            value_getter=property_value(
+                IncreaseConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+    )
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0x75, 0xA, 0x1, 0x0]), f"Poisonous")
-    
-@dataclass(eq=False)
-class ShockingUpgrade(WeaponPrefix):
-    damage_type: DamageType | None = None
+        return GWStringEncoded(self.get_text_color(True) + bytes([0x75, 0xA, 0x1, 0x0]), "Poisonous")
 
+@dataclass(eq=False)
+class ShockingUpgrade(DamageTypeUpgrade):
     id = ItemUpgrade.Shocking
-    property_identifiers = [
-        ModifierIdentifier.DamageTypeProperty,
-    ]
+    damage_type = DamageType.Lightning
 
-    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamageTypeProperty,
+            target="damage_type",
+            fixed_value=DamageType.Lightning,
+            value_getter=property_value(
+                DamageTypeProperty,
+                lambda prop: prop.damage_type,
+            ),
+        ),
+    )
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0xD6, 0x8, 0x1, 0x0]), f"Shocking")
-    
+        return GWStringEncoded(self.get_text_color(True) + bytes([0xD6, 0x8, 0x1, 0x0]), "Shocking")
+
 @dataclass(eq=False)
-class SilencingUpgrade(WeaponPrefix):
-    condition: Ailment | None = None
-
+class SilencingUpgrade(IncreaseConditionDurationUpgrade):
     id = ItemUpgrade.Silencing
-    property_identifiers = [
-        ModifierIdentifier.IncreaseConditionDuration,
-    ]
+    condition = Ailment.Dazed
 
-    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.IncreaseConditionDuration,
+            target="condition",
+            fixed_value=Ailment.Dazed,
+            value_getter=property_value(
+                IncreaseConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+    )
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0x6C, 0xA, 0x1, 0x0]), f"Silencing")
-    
+        return GWStringEncoded(self.get_text_color(True) + bytes([0x6C, 0xA, 0x1, 0x0]), "Silencing")
+
 @dataclass(eq=False)
 class SunderingUpgrade(WeaponPrefix):
-    chance: int = 0
-    armor_penetration: int = 0
-
     id = ItemUpgrade.Sundering
-    property_identifiers = [
-        ModifierIdentifier.ArmorPenetration,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPenetration, ModifierType.Arg1, 10, 20)
-    max_modifier_values = {
-        ModifierIdentifier.ArmorPenetration: (20, 20),
-    }
+    chance: int = 20
+    armor_penetration: int = 20
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPenetration,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                ArmorPenetration,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPenetration,
+            target="armor_penetration",
+            fixed_value=20,
+            value_getter=property_value(
+                ArmorPenetration,
+                lambda prop: prop.armor_penetration,
+            ),
+        ),
+    )
 
+    def create_encoded_description(self) -> GWStringEncoded:
+        encoded = bytes([
+            *self.get_text_color(),
+            *GWEncoded.PLUS_PERCENT_TEMPLATE, 0x45, 0xA, 0x1, 0x0, 0x1, 0x1, self.armor_penetration, 0x1, 0x1, 0x0,
+            *GWEncoded.ITEM_DULL,
+            *GWEncoded.PARENTHESIS_STR1,
+            *GWEncoded.CHANCE_TEMPLATE, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0,
+            0x1, 0x0
+        ])
+        return GWStringEncoded(encoded, f"Armor penetration +{self.armor_penetration}% (Chance: {self.chance}%)")
     
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0x74, 0xA, 0x1, 0x0]), f"Sundering")
-    
+        return GWStringEncoded(self.get_text_color(True) + bytes([0x74, 0xA, 0x1, 0x0]), "Sundering")
+
 @dataclass(eq=False)
 class SwiftUpgrade(WeaponPrefix):
-    chance: int = 0
-
     id = ItemUpgrade.Swift
-    property_identifiers = [
-        ModifierIdentifier.HalvesCastingTimeGeneral,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesCastingTimeGeneral, ModifierType.Arg1, 5, 10)
+    chance: int = 10
 
-    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeGeneral,
+            target="chance",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                HalvesCastingTimeGeneral,
+                lambda prop: prop.chance,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.HALVES_CASTING_BYTES]), "Halves casting time of spells"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0x1, 0x81, 0x95, 0x5D, 0x1, 0x0]), f"Swift")
-    
+        return GWStringEncoded(self.get_text_color(True) + bytes([0x1, 0x81, 0x95, 0x5D, 0x1, 0x0]), "Swift")
+
 @dataclass(eq=False)
-class VampiricUpgrade(WeaponPrefix):
-    health_regeneration: int = 0
-    health_steal: int = 0
+class VampiricMinorUpgrade(WeaponPrefix):
+    id = ItemUpgrade.VampiricMinor
+    health_regeneration: int = -1
+    health_steal: int = 3
 
-    id = ItemUpgrade.Vampiric
-    property_identifiers = [
-        ModifierIdentifier.HealthRegeneneration,
-        ModifierIdentifier.HealthStealOnHit,
-    ]
-    # modifier_range = ModifierRange(ModifierIdentifier.HealthStealOnHit, ModifierType.Arg1, 1, 5)
-
-
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.HealthRegeneneration,
+            target="health_regeneration",
+            fixed_value=-1,
+            value_getter=property_value(
+                HealthRegeneneration,
+                lambda prop: prop.health_regeneration,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HealthStealOnHit,
+            target="health_steal",
+            fixed_value=3,
+            value_getter=property_value(
+                HealthStealOnHit,
+                lambda prop: prop.health_steal,
+            ),
+        ),
+    )
     
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._bonus_colon_num(self.get_text_color(), GWEncoded.LIFE_DRAINING_BYTES, self.health_steal, "Life Draining"),
+            GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.HEALTH_REGEN_BYTES, abs(self.health_regeneration), "Health regeneration")
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, "no encoded description")
+    
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0x71, 0xA, 0x1, 0x0]), f"Vampiric")
+        return GWStringEncoded(self.get_text_color(True) + bytes([0x71, 0xA, 0x1, 0x0]), "Vampiric")
+
+@dataclass(eq=False)
+class VampiricMajorUpgrade(WeaponPrefix):
+    id = ItemUpgrade.VampiricMajor
+    health_regeneration: int = -1
+    health_steal: int = 5
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.HealthRegeneneration,
+            target="health_regeneration",
+            fixed_value=-1,
+            value_getter=property_value(
+                HealthRegeneneration,
+                lambda prop: prop.health_regeneration,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HealthStealOnHit,
+            target="health_steal",
+            fixed_value=5,
+            value_getter=property_value(
+                HealthStealOnHit,
+                lambda prop: prop.health_steal,
+            ),
+        ),
+    )
     
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._bonus_colon_num(self.get_text_color(), GWEncoded.LIFE_DRAINING_BYTES, self.health_steal, "Life Draining"),
+            GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.HEALTH_REGEN_BYTES, abs(self.health_regeneration), "Health regeneration")
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, "no encoded description")
+    
+
+    def create_encoded_name(self) -> GWStringEncoded:
+        return GWStringEncoded(self.get_text_color(True) + bytes([0x71, 0xA, 0x1, 0x0]), "Vampiric")
+
 @dataclass(eq=False)
 class ZealousUpgrade(WeaponPrefix):
-    energy_regeneration: int = 0
-    energy_gain: int = 0
-
     id = ItemUpgrade.Zealous
-    property_identifiers = [
-        ModifierIdentifier.EnergyRegeneration,
-        ModifierIdentifier.EnergyGainOnHit,
-    ]
+    energy_regeneration: int = -1
+    energy_gain: int = 1
 
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.EnergyGainOnHit,
+            target="energy_gain",
+            fixed_value=1,
+            value_getter=property_value(
+                EnergyGainOnHit,
+                lambda prop: prop.energy_gain,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.EnergyRegeneration,
+            target="energy_regeneration",
+            fixed_value=-1,
+            value_getter=property_value(
+                EnergyRegeneration,
+                lambda prop: prop.energy_regeneration,
+            ),
+        ),
+    )
 
-
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._bonus_colon_num(self.get_text_color(), GWEncoded.ENERGY_GAIN_ON_HIT_BYTES, self.energy_gain, "Energy gain on hit"),
+            GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.ENERGY_REGEN_BYTES, abs(self.energy_regeneration), "Energy regeneration")
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, "no encoded description")
+    
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + bytes([0x6E, 0xA, 0x1, 0x0]), f"Zealous")
-
+        return GWStringEncoded(self.get_text_color(True) + bytes([0x6E, 0xA, 0x1, 0x0]), "Zealous")
+    
 #endregion Prefixes
-  
+
 #region Suffixes
+
 @dataclass(eq=False)
 class WeaponSuffix(WeaponUpgrade):
     mod_type = ItemUpgradeType.Suffix
-    
+
+    def create_upgrade_name(self, item_type: ItemType) -> GWStringEncoded:
+        encoded_upgrade_component = GWEncoded.WEAPON_SUFFIXES.get(item_type) or bytes()
+        if not encoded_upgrade_component:
+            return self.create_encoded_name()
+
+        encoded_name = self.create_encoded_name()
+        color_bytes = self.get_text_color(True)
+        suffix_prefix = bytes([*color_bytes, *GWEncoded.STR1_OF_STR2, *GWEncoded.PLACEHOLDER_TO_REMOVE])
+        suffix = encoded_name.encoded[len(suffix_prefix):] if encoded_name.encoded.startswith(suffix_prefix) else encoded_name.encoded
+        return GWStringEncoded(
+            bytes([*color_bytes, *encoded_upgrade_component, *suffix]),
+            encoded_name.fallback,
+            encoded_name.placeholder_bytes,
+            encoded_name.placeholder_replacement,
+        )
+
+#region OfAttributeUpgrade
 @dataclass(eq=False)
 class OfAttributeUpgrade(WeaponSuffix):
-    chance: int = 0
+    id = ItemUpgrade.OfAttribute
+    chance: int = 20
     attribute: Attribute = Attribute.None_
     attribute_level: int = 1
-
-    id = ItemUpgrade.OfAttribute
-    property_identifiers = [
-        ModifierIdentifier.AttributePlusOne,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.AttributePlusOne, ModifierType.Arg2, 10, 20)
-        
-
-
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        attribute_bytes = GWEncoded._attribute_bytes(self.attribute)
+        if attribute_bytes:
+            base = GWStringEncoded(bytes([*self.get_text_color(), 0x84, 0xA, 0xA, 0x1, *attribute_bytes, 0x1, 0x0, 0x1, 0x1, 0x1, self.attribute_level]), f"{GWEncoded._attribute_name(self.attribute)} +{self.attribute_level}")
+            clause_raw = bytes([0xC1, 0xA, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0])
+            
+            return GWEncoded._append_line_with_fallback(base, GWEncoded._dull_parenthesized(clause_raw, f"({self.chance}% chance while using skills)"), f"({self.chance}% chance while using skills)")
+        return GWStringEncoded(bytes(), f"{GWEncoded._attribute_name(self.attribute)} +1 ({self.chance}% chance while using skills)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0xB, 0x1]) + GWEncoded.ATTRIBUTE_NAMES.get(self.attribute, bytes()) + bytes([0x1, 0x0, 0x1, 0x0]), f"of {AttributeNames.get(self.attribute, self.attribute.name)}", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Attribute"])
-        
-    
+
+    def equals(self, other: object) -> bool:
+        return (
+            isinstance(other, OfAttributeUpgrade)
+            and self.attribute == other.attribute
+            and self.attribute_level == other.attribute_level
+            and self.chance == other.chance
+        )
+
+    def matches(self, other: object) -> bool:
+        return self.equals(other)
+
+@dataclass(eq=False)
+class OfDivineFavorUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.DivineFavor
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.DivineFavor,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfHealingPrayersUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.HealingPrayers
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.HealingPrayers,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfSmitingPrayersUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.SmitingPrayers
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.SmitingPrayers,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfProtectionPrayersUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.ProtectionPrayers
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.ProtectionPrayers,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfBloodMagicUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.BloodMagic
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.BloodMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfDeathMagicUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.DeathMagic
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.DeathMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfCursesUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.Curses
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.Curses,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfIllusionMagicUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.IllusionMagic
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.IllusionMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfDominationMagicUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.DominationMagic
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.DominationMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfInspirationMagicUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.InspirationMagic
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.InspirationMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfAirMagicUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.AirMagic
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.AirMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfEarthMagicUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.EarthMagic
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.EarthMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfFireMagicUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.FireMagic
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.FireMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfWaterMagicUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.WaterMagic
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.WaterMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfSpawningPowerUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.SpawningPower
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.SpawningPower,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfCommuningUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.Communing
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.Communing,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfRestorationMagicUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.RestorationMagic
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.RestorationMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfChannelingMagicUpgrade(OfAttributeUpgrade):
+    attribute = Attribute.ChannelingMagic
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.ChannelingMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+#endregion OfAttributeUpgrade
+
 @dataclass(eq=False)
 class OfAptitudeUpgrade(WeaponSuffix):
-    chance: int = 0
-
     id = ItemUpgrade.OfAptitude
-    property_identifiers = [
-        ModifierIdentifier.HalvesCastingTimeItemAttribute,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesCastingTimeItemAttribute, ModifierType.Arg1, 10, 20)
+    chance: int = 20
 
-    
-    def create_encoded_name(self):
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x96, 0x5D, 0x1, 0x0]), f"of Aptitude", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Aptitude"])
-    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeItemAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeItemAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.HALVES_CASTING_ITEM_ATTRIBUTE_BYTES]), "Halves casting time on spells of item's attribute"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+
+    def create_encoded_name(self) -> GWStringEncoded:
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x96, 0x5D, 0x1, 0x0]), "of Aptitude", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Aptitude"])
+
 @dataclass(eq=False)
 class OfAxeMasteryUpgrade(OfAttributeUpgrade):
     id = ItemUpgrade.OfAxeMastery
-    attribute: Attribute = Attribute.AxeMastery
+    attribute = Attribute.AxeMastery
     
-    def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0xB, 0x1]) + GWEncoded.ATTRIBUTE_NAMES.get(self.attribute, bytes()) + bytes([0x1, 0x0, 0x1, 0x0]), f"of {AttributeNames.get(self.attribute, self.attribute.name)}", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Axe Mastery"])
-        
-    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.AxeMastery,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
 @dataclass(eq=False)
 class OfDaggerMasteryUpgrade(OfAttributeUpgrade):
     id = ItemUpgrade.OfDaggerMastery
-    attribute: Attribute = Attribute.DaggerMastery
-        
-    def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0xB, 0x1]) + GWEncoded.ATTRIBUTE_NAMES.get(self.attribute, bytes()) + bytes([0x1, 0x0, 0x1, 0x0]), f"of {AttributeNames.get(self.attribute, self.attribute.name)}", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Dagger Mastery"])
-    
+    attribute = Attribute.DaggerMastery
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.DaggerMastery,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
 @dataclass(eq=False)
 class OfDefenseUpgrade(WeaponSuffix):
-    armor: int = 0
-
     id = ItemUpgrade.OfDefense
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlus,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlus, ModifierType.Arg2, 4, 5)
+    armor: int = 5
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlus,
+            target="armor",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                ArmorPlus,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x77, 0xA, 0x1, 0x0]), f"of Defense", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Defense"])
-    
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x77, 0xA, 0x1, 0x0]), "of Defense", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Defense"])
+
 @dataclass(eq=False)
 class OfDevotionUpgrade(WeaponSuffix):
-    health: int = 0
-
     id = ItemUpgrade.OfDevotion
-    property_identifiers = [
-        ModifierIdentifier.HealthPlusEnchanted,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HealthPlusEnchanted, ModifierType.Arg1, 30, 45)
+    health: int = 45
 
-    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HealthPlusEnchanted,
+            target="health",
+            min_value=30,
+            max_value=45,
+            value_getter=property_value(
+                HealthPlusEnchanted,
+                lambda prop: prop.health,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.HEALTH_BYTES, self.health, "Health"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_ENCHANTED_BYTES, "(while Enchanted)"), "(while Enchanted)")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x97, 0x5D, 0x1, 0x0]), f"of Devotion", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Devotion"])
-    
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x97, 0x5D, 0x1, 0x0]), "of Devotion", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Devotion"])
+
 @dataclass(eq=False)
 class OfEnchantingUpgrade(WeaponSuffix):
-    enchantment_duration: int = 0
-
     id = ItemUpgrade.OfEnchanting
-    property_identifiers = [
-        ModifierIdentifier.IncreaseEnchantmentDuration,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.IncreaseEnchantmentDuration, ModifierType.Arg2, 10, 20)
+    enchantment_duration: int = 20
 
-    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.IncreaseEnchantmentDuration,
+            target="enchantment_duration",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                IncreaseEnchantmentDuration,
+                lambda prop: prop.enchantment_duration,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes([*self.get_text_color(), 0xA, 0x1, 0xA2, 0xA, 0x1, 0x1, self.enchantment_duration, 0x1, 0x1, 0x0]), f"Enchantments last {self.enchantment_duration}% longer")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x78, 0xA, 0x1, 0x0]), f"of Enchanting", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Enchanting"])
-    
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x78, 0xA, 0x1, 0x0]), "of Enchanting", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Enchanting"])
+
 @dataclass(eq=False)
 class OfEnduranceUpgrade(WeaponSuffix):
-    health: int = 0
-
     id = ItemUpgrade.OfEndurance
-    property_identifiers = [
-        ModifierIdentifier.HealthPlusStance,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HealthPlusStance, ModifierType.Arg1, 30, 45)
+    health: int = 45
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HealthPlusStance,
+            target="health",
+            min_value=30,
+            max_value=45,
+            value_getter=property_value(
+                HealthPlusStance,
+                lambda prop: prop.health,
+            ),
+        ),
+    )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.HEALTH_BYTES, self.health, "Health"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_IN_A_STANCE_BYTES, "(while in a Stance)"), "(while in a Stance)")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x98, 0x5D, 0x1, 0x0]), f"of Endurance", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Endurance"])
-    
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x98, 0x5D, 0x1, 0x0]), "of Endurance", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Endurance"])
+
 @dataclass(eq=False)
 class OfFortitudeUpgrade(WeaponSuffix):
-    health: int = 0
-
     id = ItemUpgrade.OfFortitude
-    property_identifiers = [
-        ModifierIdentifier.HealthPlus,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HealthPlus, ModifierType.Arg1, 10, 30)
+    health: int = 30
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HealthPlus,
+            target="health",
+            min_value=10,
+            max_value=30,
+            value_getter=property_value(
+                HealthPlus,
+                lambda prop: prop.health,
+            ),
+        ),
+    )
 
     
-    def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x79, 0xA, 0x1, 0x0]), f"of Fortitude", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Fortitude"])
+    def create_upgrade_name(self, item_type):
+        encoded_upgrade_component = (GWEncoded.WEAPON_PREFIXES.get(item_type) if self.mod_type == ItemUpgradeType.Prefix else GWEncoded.WEAPON_SUFFIXES.get(item_type)) or bytes()
+        return GWStringEncoded(bytes([*self.get_text_color(True), *encoded_upgrade_component, 0x79, 0xA, 0x1, 0x0]), f"of Fortitude") if encoded_upgrade_component else self.create_encoded_name()
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.HEALTH_BYTES, self.health, "Health")
+
+    def create_encoded_name(self) -> GWStringEncoded:
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x79, 0xA, 0x1, 0x0]), "of Fortitude", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Fortitude"])
+
 @dataclass(eq=False)
 class OfHammerMasteryUpgrade(OfAttributeUpgrade):
     id = ItemUpgrade.OfHammerMastery
-    attribute: Attribute = Attribute.HammerMastery
+    attribute = Attribute.HammerMastery
     
-    def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0xB, 0x1]) + GWEncoded.ATTRIBUTE_NAMES.get(self.attribute, bytes()) + bytes([0x1, 0x0, 0x1, 0x0]), f"of {AttributeNames.get(self.attribute, self.attribute.name)}", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Hammer Mastery"])
-    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.HammerMastery,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
 @dataclass(eq=False)
 class OfMarksmanshipUpgrade(OfAttributeUpgrade):
     id = ItemUpgrade.OfMarksmanship
-    attribute: Attribute = Attribute.Marksmanship
-    
-    def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0xB, 0x1]) + GWEncoded.ATTRIBUTE_NAMES.get(self.attribute, bytes()) + bytes([0x1, 0x0, 0x1, 0x0]), f"of {AttributeNames.get(self.attribute, self.attribute.name)}", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Marksmanship"])
-    
+    attribute = Attribute.Marksmanship
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.Marksmanship,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
 @dataclass(eq=False)
 class OfMasteryUpgrade(WeaponSuffix):
-    chance: int = 0
-    attribute_level: int = 0
-
     id = ItemUpgrade.OfMastery
-    property_identifiers = [
-        ModifierIdentifier.AttributePlusOneItem,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.AttributePlusOneItem, ModifierType.Arg1, 10, 20)
+    chance: int = 20
+    attribute_level: int = 1
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOneItem,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOneItem,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOneItem,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOneItem,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
 
-    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.ITEM_ATTRIBUTE_PLUS_ONE_BYTES, self.attribute_level]), "Item's attribute +1"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x99, 0x5D, 0x1, 0x0]), f"of Mastery", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Mastery"])
-    
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x99, 0x5D, 0x1, 0x0]), "of Mastery", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Mastery"])
+
 @dataclass(eq=False)
 class OfMemoryUpgrade(WeaponSuffix):
-    chance: int = 0
-
     id = ItemUpgrade.OfMemory
-    property_identifiers = [
-        ModifierIdentifier.HalvesSkillRechargeItemAttribute,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesSkillRechargeItemAttribute, ModifierType.Arg1, 10, 20)
+    chance: int = 20
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeItemAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeItemAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+    )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.HALVES_RECHARGE_ITEM_ATTRIBUTE_BYTES]), "Halves skill recharge on spells of item's attribute"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x9A, 0x5D, 0x1, 0x0]), f"of Memory", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Memory"])
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x9A, 0x5D, 0x1, 0x0]), "of Memory", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Memory"])
 
 @dataclass(eq=False)
 class OfQuickeningUpgrade(WeaponSuffix):
-    chance: int = 0
-
     id = ItemUpgrade.OfQuickening
-    property_identifiers = [
-        ModifierIdentifier.HalvesSkillRechargeGeneral,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesSkillRechargeGeneral, ModifierType.Arg1, 5, 10)
+    chance: int = 10
 
-    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeGeneral,
+            target="chance",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                HalvesSkillRechargeGeneral,
+                lambda prop: prop.chance,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.HALVES_RECHARGE_BYTES]), "Halves skill recharge of spells"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x9B, 0x5D, 0x1, 0x0]), f"of Quickening", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Quickening"])
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x9B, 0x5D, 0x1, 0x0]), "of Quickening", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Quickening"])
 
 @dataclass(eq=False)
 class OfScytheMasteryUpgrade(OfAttributeUpgrade):
     id = ItemUpgrade.OfScytheMastery
-    attribute: Attribute = Attribute.ScytheMastery
+    attribute = Attribute.ScytheMastery
     
-    def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0xB, 0x1]) + GWEncoded.ATTRIBUTE_NAMES.get(self.attribute, bytes()) + bytes([0x1, 0x0, 0x1, 0x0]), f"of {AttributeNames.get(self.attribute, self.attribute.name)}", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Scythe Mastery"])
-    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.ScytheMastery,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
+
 @dataclass(eq=False)
 class OfShelterUpgrade(WeaponSuffix):
-    armor: int = 0
-
     id = ItemUpgrade.OfShelter
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsPhysical,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusVsPhysical, ModifierType.Arg2, 4, 7)
+    armor: int = 7
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsPhysical,
+            target="armor",
+            min_value=4,
+            max_value=7,
+            value_getter=property_value(
+                ArmorPlusVsPhysical,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor"), GWEncoded._dull_parenthesized(GWEncoded.VS_PHYSICAL_DAMAGE_BYTES, "(vs. physical damage)"), "(vs. physical damage)")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x7B, 0xA, 0x1, 0x0]), f"of Shelter", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Shelter"])
-    
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x7B, 0xA, 0x1, 0x0]), "of Shelter", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Shelter"])
+
+#region OfSlayingUpgrade
+
 @dataclass(eq=False)
 class OfSlayingUpgrade(WeaponSuffix):
-    species: ItemBaneSpecies = ItemBaneSpecies.Unknown
-    damage_increase: int = 0
-
     id = ItemUpgrade.OfSlaying
-    modifier_range = ModifierRange(ModifierIdentifier.DamagePlusVsSpecies, ModifierType.Arg1, 10, 20)
-    
-    property_identifiers = [
-        ModifierIdentifier.DamagePlusVsSpecies,
-        # ModifierIdentifier.BaneSpecies,
-    ]
+    species: ItemBaneSpecies = ItemBaneSpecies.Unknown
+    damage_increase: int = 20
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_percent(self.get_text_color(), bytes([*GWEncoded.DAMAGE_TEXT, 0x1, 0x0]), self.damage_increase, f"Damage +{self.damage_increase}%"), GWEncoded._dull_parenthesized(bytes([*GWEncoded.VS_STR1, *GWEncoded.SLAYING_BANE.get(self.species, bytes())]), f"(vs. {self.species.name})"), f"(vs. {self.species.name})")
 
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + GWEncoded.SLAYING_SUFFIXES.get(self.species, bytes()), f"of {self.species.name}-Slaying", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", f"{self.species.name}-Slaying" if self.species != ItemBaneSpecies.Unknown else "Slaying"])
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0xB, 0x1]) + GWEncoded.SLAYING_SUFFIXES.get(self.species, bytes()) + bytes([0x1, 0x0, 0x1, 0x0, 0x0, 0x0]), 
+                               f"of {self.species.name}-Slaying", 
+                               GWEncoded.PLACEHOLDER_TO_REMOVE, 
+                               ["", f"{self.species.name}-Slaying" if self.species != ItemBaneSpecies.Unknown else "Slaying"])
+
+@dataclass(eq=False)
+class OfUndeadSlayingUpgrade(OfSlayingUpgrade):
+    species = ItemBaneSpecies.Undead
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Undead,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="damage_increase",
+            min_value=15,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfCharrSlayingUpgrade(OfSlayingUpgrade):
+    species = ItemBaneSpecies.Charr
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Charr,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="damage_increase",
+            min_value=15,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfTrollsSlayingUpgrade(OfSlayingUpgrade):
+    species = ItemBaneSpecies.Trolls
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Trolls,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="damage_increase",
+            min_value=15,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfPlantsSlayingUpgrade(OfSlayingUpgrade):
+    species = ItemBaneSpecies.Plants
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Plants,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="damage_increase",
+            min_value=15,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfSkeletonsSlayingUpgrade(OfSlayingUpgrade):
+    species = ItemBaneSpecies.Skeletons
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Skeletons,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="damage_increase",
+            min_value=15,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfGiantsSlayingUpgrade(OfSlayingUpgrade):
+    species = ItemBaneSpecies.Giants
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Giants,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="damage_increase",
+            min_value=15,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfDwarvesSlayingUpgrade(OfSlayingUpgrade):
+    species = ItemBaneSpecies.Dwarves
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Dwarves,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="damage_increase",
+            min_value=15,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfTengusSlayingUpgrade(OfSlayingUpgrade):
+    species = ItemBaneSpecies.Tengus
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Tengus,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="damage_increase",
+            min_value=15,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfDemonsSlayingUpgrade(OfSlayingUpgrade):
+    species = ItemBaneSpecies.Demons
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Demons,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="damage_increase",
+            min_value=15,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfDragonsSlayingUpgrade(OfSlayingUpgrade):
+    species = ItemBaneSpecies.Dragons
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Dragons,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="damage_increase",
+            min_value=15,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfOgresSlayingUpgrade(OfSlayingUpgrade):
+    species = ItemBaneSpecies.Ogres
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Ogres,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusVsSpecies,
+            target="damage_increase",
+            min_value=15,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusVsSpecies,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+#endregion OfSlayingUpgrade
 
 @dataclass(eq=False)
 class OfSpearMasteryUpgrade(OfAttributeUpgrade):
     id = ItemUpgrade.OfSpearMastery
-    attribute: Attribute = Attribute.SpearMastery
+    attribute = Attribute.SpearMastery
 
-    def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0xB, 0x1]) + GWEncoded.ATTRIBUTE_NAMES.get(self.attribute, bytes()) + bytes([0x1, 0x0, 0x1, 0x0]), f"of {AttributeNames.get(self.attribute, self.attribute.name)}", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Spear Mastery"])
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.SpearMastery,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
 
 @dataclass(eq=False)
 class OfSwiftnessUpgrade(WeaponSuffix):
-    chance: int = 0
-
     id = ItemUpgrade.OfSwiftness
-    property_identifiers = [
-        ModifierIdentifier.HalvesCastingTimeGeneral,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesCastingTimeGeneral, ModifierType.Arg1, 5, 10)
+    chance: int = 10
 
-    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeGeneral,
+            target="chance",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                HalvesCastingTimeGeneral,
+                lambda prop: prop.chance,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.HALVES_CASTING_BYTES]), "Halves casting time of spells"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x7C, 0xA, 0x1, 0x0]), f"of Swiftness", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Swiftness"])
-    
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x7C, 0xA, 0x1, 0x0]), "of Swiftness", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Swiftness"])
+
 @dataclass(eq=False)
 class OfSwordsmanshipUpgrade(OfAttributeUpgrade):
     id = ItemUpgrade.OfSwordsmanship
-    attribute: Attribute = Attribute.Swordsmanship
+    attribute = Attribute.Swordsmanship
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.Swordsmanship,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+    )
     
-    def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0xB, 0x1]) + GWEncoded.ATTRIBUTE_NAMES.get(self.attribute, bytes()) + bytes([0x1, 0x0, 0x1, 0x0]), f"of {AttributeNames.get(self.attribute, self.attribute.name)}", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Swordsmanship"])
-    
+#region OfTheProfessionUpgrade
 @dataclass(eq=False)
 class OfTheProfessionUpgrade(WeaponSuffix):
+    id = ItemUpgrade.OfTheProfession
     profession: Profession = Profession._None
     attribute: Attribute = Attribute.None_
     attribute_level: int = 5
 
-    id = ItemUpgrade.OfTheProfession
-    modifier_range = ModifierRange(ModifierIdentifier.OfTheProfession, ModifierType.Arg2, 4, 5)
-    
-    property_identifiers = [
-        ModifierIdentifier.OfTheProfession,
-    ]
-    
-    def __post_init__(self):
-        super().__post_init__()
-        if self.profession == Profession._None:
-            self.profession = self.attribute.get_profession()
-    
+    def create_encoded_description(self) -> GWStringEncoded:
+        encoded_bytes = bytes([*self.get_text_color(), 0x86, 0xA, 0xA, 0x1, *GWEncoded.ATTRIBUTE_NAMES.get(self.attribute, bytes()), 0x1, 0x0, 0x1, 0x1, self.attribute_level, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x2, 0x81, 0xA8, 0x38, 0x1, 0x0])
+        return GWStringEncoded(encoded_bytes, f"{AttributeNames.get(self.attribute)}: {self.attribute_level} (if your rank is lower. No effect in PvP.)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + GWEncoded.THE_PROFESSION.get(self.profession, bytes()), f"of {self.profession.name if self.profession != Profession._None else 'Unknown Profession'}", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", self.profession.name if self.profession != Profession._None else "Profession"])
-        
-    
+
+    def equals(self, other: object) -> bool:
+        return (
+            isinstance(other, OfTheProfessionUpgrade)
+            and self.profession == other.profession
+            and self.attribute == other.attribute
+            and self.attribute_level == other.attribute_level
+        )
+
+    def matches(self, other: object) -> bool:
+        return self.equals(other)
+
+@dataclass(eq=False)
+class OfTheWarriorUpgrade(OfTheProfessionUpgrade):
+    profession = Profession.Warrior
+    attribute = Attribute.Strength
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute",
+            fixed_value=Attribute.Strength,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute_level",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="profession",
+            fixed_value=Profession.Warrior,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.profession,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfTheRangerUpgrade(OfTheProfessionUpgrade):
+    profession = Profession.Ranger
+    attribute = Attribute.Expertise
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute",
+            fixed_value=Attribute.Expertise,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute_level",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="profession",
+            fixed_value=Profession.Ranger,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.profession,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfTheMonkUpgrade(OfTheProfessionUpgrade):
+    profession = Profession.Monk
+    attribute = Attribute.DivineFavor
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute",
+            fixed_value=Attribute.DivineFavor,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute_level",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="profession",
+            fixed_value=Profession.Monk,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.profession,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfTheNecromancerUpgrade(OfTheProfessionUpgrade):
+    profession = Profession.Necromancer
+    attribute = Attribute.SoulReaping
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute",
+            fixed_value=Attribute.SoulReaping,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute_level",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="profession",
+            fixed_value=Profession.Necromancer,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.profession,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfTheMesmerUpgrade(OfTheProfessionUpgrade):
+    profession = Profession.Mesmer
+    attribute = Attribute.FastCasting
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute",
+            fixed_value=Attribute.FastCasting,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute_level",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="profession",
+            fixed_value=Profession.Mesmer,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.profession,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfTheElementalistUpgrade(OfTheProfessionUpgrade):
+    profession = Profession.Elementalist
+    attribute = Attribute.EnergyStorage
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute",
+            fixed_value=Attribute.EnergyStorage,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute_level",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="profession",
+            fixed_value=Profession.Elementalist,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.profession,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfTheAssassinUpgrade(OfTheProfessionUpgrade):
+    profession = Profession.Assassin
+    attribute = Attribute.CriticalStrikes
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute",
+            fixed_value=Attribute.CriticalStrikes,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute_level",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="profession",
+            fixed_value=Profession.Assassin,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.profession,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfTheRitualistUpgrade(OfTheProfessionUpgrade):
+    profession = Profession.Ritualist
+    attribute = Attribute.SpawningPower
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute",
+            fixed_value=Attribute.SpawningPower,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute_level",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="profession",
+            fixed_value=Profession.Ritualist,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.profession,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfTheParagonUpgrade(OfTheProfessionUpgrade):
+    profession = Profession.Paragon
+    attribute = Attribute.Leadership
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute",
+            fixed_value=Attribute.Leadership,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute_level",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="profession",
+            fixed_value=Profession.Paragon,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.profession,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class OfTheDervishUpgrade(OfTheProfessionUpgrade):
+    profession = Profession.Dervish
+    attribute = Attribute.Mysticism
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute",
+            fixed_value=Attribute.Mysticism,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="attribute_level",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.OfTheProfession,
+            target="profession",
+            fixed_value=Profession.Dervish,
+            value_getter=property_value(
+                OfTheProfession,
+                lambda prop: prop.profession,
+            ),
+        ),
+    )
+#endregion OfTheProfessionUpgrade
+
 @dataclass(eq=False)
 class OfValorUpgrade(WeaponSuffix):
-    health: int = 0
-
     id = ItemUpgrade.OfValor
-    property_identifiers = [
-        ModifierIdentifier.HealthPlusHexed,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HealthPlusHexed, ModifierType.Arg1, 45, 60)
+    health: int = 60
 
-    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HealthPlusHexed,
+            target="health",
+            min_value=45,
+            max_value=60,
+            value_getter=property_value(
+                HealthPlusHexed,
+                lambda prop: prop.health,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.HEALTH_BYTES, self.health, "Health"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_HEXED_BYTES, "(while Hexed)"), "(while Hexed)")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True)+ GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x9C, 0x5D, 0x1, 0x0]), f"of Valor", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Valor"])
-    
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x1, 0x81, 0x9C, 0x5D, 0x1, 0x0]), "of Valor", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Valor"])
+
 @dataclass(eq=False)
 class OfWardingUpgrade(WeaponSuffix):
-    armor: int = 0
-
     id = ItemUpgrade.OfWarding
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsElemental,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusVsElemental, ModifierType.Arg2, 4, 7)
+    armor: int = 7
 
-    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsElemental,
+            target="armor",
+            min_value=4,
+            max_value=7,
+            value_getter=property_value(
+                ArmorPlusVsElemental,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor"), GWEncoded._dull_parenthesized(GWEncoded.VS_ELEMENTAL_DAMAGE_BYTES, "(vs. elemental damage)"), "(vs. elemental damage)")
+
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x7D, 0xA, 0x1, 0x0]), f"of Warding", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Warding"])
+        return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0x7D, 0xA, 0x1, 0x0]), "of Warding", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", "Warding"])
 
 #endregion Suffixes
 
-#region Inscriptions
+#region Inscriptions    
 @dataclass(eq=False)
 class Inscription(Upgrade):
     mod_type = ItemUpgradeType.Inscription
-    inventory_icon: ClassVar[str]
-    id: ClassVar[ItemUpgrade]
-    target_item_type: ClassVar[ItemType]
-    modifier_range: ClassVar[Optional[ModifierRange]] = None
+    target_item_type: ItemType = field(init=False, default=ItemType.Unknown, repr=False, compare=False)
+
+    @classmethod
+    def _pre_compose(cls, upgrade: "Upgrade", mod: DecodedModifier, all_modifiers: list[DecodedModifier], remaining_modifiers: list[DecodedModifier]) -> None:
+        inscription = cast(Inscription, upgrade)
+        inscription.target_item_type = cls.id.get_item_type(inscription.upgrade_id)   
+
+class OffhandInscription(Inscription):
+    target_item_type = ItemType.Offhand
+    
+class WeaponInscription(Inscription):
+    target_item_type = ItemType.Weapon
+    
+class MartialWeaponInscription(Inscription):
+    target_item_type = ItemType.MartialWeapon
+    
+class OffhandOrShieldInscription(Inscription):
+    target_item_type = ItemType.OffhandOrShield
+    
+class ReduceConditionDurationInscription(OffhandOrShieldInscription):
+    condition: Reduced_Ailment | None = None
 
     def create_encoded_description(self) -> GWStringEncoded:
-        if not self.properties:
+        if self.condition is not None:
+            fallback = f"Reduces {self.condition.name} duration on you by 20% (Stacking)"
+            encoded = GWEncoded.REDUCED_CONDITION_BYTES.get(self.condition)
+            base = GWStringEncoded(bytes([*self.get_text_color(), *encoded]), fallback) if encoded else GWStringEncoded(bytes(), fallback)
+            
+            return GWEncoded._append_line_with_fallback(base, GWEncoded._dull_parenthesized(GWEncoded.STACKING_BYTES, "(Stacking)"), fallback)
+        
+        return super().create_encoded_description()
+
+class ArmorVsDamageTypeInscription(OffhandOrShieldInscription):
+    armor: int = 10
+    damage_type: DamageType | None = None
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        if self.damage_type is None:
             return super().create_encoded_description()
-        parts = [prop.encoded_description for prop in self.properties.values() if prop.encoded_description]
-        return GWEncoded.combine_encoded_strings(parts, "no encoded description")
+        
+        base = GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor")
+        clause_bytes = GWEncoded.VS_DAMAGE_BYTES.get(self.damage_type)
+        if clause_bytes:
+            return GWEncoded._append_line_with_fallback(base, GWEncoded._dull_parenthesized(clause_bytes, f"(vs. {self.damage_type.name} damage)"), f"(vs. {self.damage_type.name} damage)")
+        return GWStringEncoded(bytes(), f"{base.fallback} (vs. {self.damage_type.name} damage)")
 
-    @property
-    def is_maxed(self) -> bool:
-        if not self.properties or not self.modifier_range:
-            return True
-
-        prop = self._get_upgrade_property(self.modifier_range.modifierIdentifier)
-        if not prop:
-            return False
-
-        value = prop.modifier.arg1 if self.modifier_range.modifier_type == ModifierType.Arg1 else prop.modifier.arg2
-        return self.modifier_range.min_value <= value <= self.modifier_range.max_value
+class EquippableItemInscription(Inscription):
+    target_item_type = ItemType.EquippableItem
+    
+class SpellcastingWeaponInscription(Inscription):
+    target_item_type = ItemType.SpellcastingWeapon
     
 #region Offhand
 @dataclass(eq=False)
-class BeJustAndFearNot(Inscription):
-    armor: int = 0
-
+class BeJustAndFearNot(OffhandInscription):
     id = ItemUpgrade.BeJustAndFearNot
+    armor: int = 10
     target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusHexed,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusHexed, ModifierType.Arg2, 5, 10)
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusHexed,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusHexed,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
     
-    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_HEXED_BYTES, "(while Hexed)"))
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x90, 0x5D, 0x1, 0x0]), f"Be Just And Fear Not")
-        
+ 
 @dataclass(eq=False)
-class DownButNotOut(Inscription):
-    armor: int = 0
-    health_threshold: int = 0
-
+class DownButNotOut(OffhandInscription):
     id = ItemUpgrade.DownButNotOut
-    target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusWhileBelow
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusWhileBelow, ModifierType.Arg2, 5, 10)
-    max_modifier_values = {
-        ModifierIdentifier.ArmorPlusWhileBelow: (50, 10),
-    }
+    
+    armor: int = 10
+    health_threshold: int = 50
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusWhileBelow,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusWhileBelow,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusWhileBelow,
+            target="health_threshold",
+            fixed_value=50,
+            value_getter=property_value(
+                ArmorPlusWhileBelow,
+                lambda prop: prop.health_threshold,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_HEALTH_BELOW_BYTES, f"(while Health is below {self.health_threshold}%)"), f"(while Health is below {self.health_threshold}%)")
 
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x8E, 0x5D, 0x1, 0x0]), f"Down But Not Out")    
     
 @dataclass(eq=False)
-class FaithIsMyShield(Inscription):
-    armor: int = 0
-
+class FaithIsMyShield(OffhandInscription):
     id = ItemUpgrade.FaithIsMyShield
-    target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusEnchanted,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusEnchanted, ModifierType.Arg2, 4, 5)
+    armor: int = 5
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusEnchanted,
+            target="armor",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                ArmorPlusEnchanted,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
     
-    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_ENCHANTED_BYTES, "(while Enchanted)"))
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x8D, 0x5D, 0x1, 0x0]), f"Faith Is My Shield")
     
 @dataclass(eq=False)
-class ForgetMeNot(Inscription):
-    chance: int = 0
-
+class ForgetMeNot(OffhandInscription):
     id = ItemUpgrade.ForgetMeNot
-    target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.HalvesSkillRechargeItemAttribute,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesSkillRechargeItemAttribute, ModifierType.Arg1, 15, 20)
+    chance: int = 20
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeItemAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeItemAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+    )
     
+    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.HALVES_RECHARGE_ITEM_ATTRIBUTE_BYTES]), "Halves skill recharge on spells of item's attribute"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x93, 0x5D, 0x1, 0x0]), f"Forget Me Not")
     
 @dataclass(eq=False)
-class HailToTheKing(Inscription):
-    armor: int = 0
-    health_threshold: int = 0
-
+class HailToTheKing(OffhandInscription):
     id = ItemUpgrade.HailToTheKing
-    target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusAbove,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusAbove, ModifierType.Arg2, 4, 5)
-    max_modifier_values = {
-        ModifierIdentifier.ArmorPlusAbove: (50, 5),
-    }
+    armor: int = 5
+    health_threshold: int = 50
 
-
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusAbove,
+            target="armor",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                ArmorPlusAbove,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusAbove,
+            target="health_threshold",
+            fixed_value=50,
+            value_getter=property_value(
+                ArmorPlusAbove,
+                lambda prop: prop.health_threshold,
+            ),
+        ),
+    )
+    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_HEALTH_ABOVE_BYTES, "(while health above 50 %)"), "(while health above 50 %)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x8F, 0x5D, 0x1, 0x0]), f"Hail To The King")
     
 @dataclass(eq=False)
-class IgnoranceIsBliss(Inscription):
-    armor: int = 0
-    energy: int = 0
-
+class IgnoranceIsBliss(OffhandInscription):
     id = ItemUpgrade.IgnoranceIsBliss
-    target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlus,
-        ModifierIdentifier.EnergyMinus,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlus, ModifierType.Arg2, 4, 5)
+    armor: int = 5
+    energy: int = 5
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlus,
+            target="armor",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                ArmorPlus,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.EnergyMinus,
+            target="energy",
+            fixed_value=5,
+            value_getter=property_value(
+                EnergyMinus,
+                lambda prop: prop.energy,
+            ),
+        ),
+    )
 
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, abs(self.armor), "Armor"),
+            GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.ENERGY_BYTES, abs(self.energy), "Energy")
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x87, 0x5D, 0x1, 0x0]), f"Ignorance Is Bliss")
     
 @dataclass(eq=False)
-class KnowingIsHalfTheBattle(Inscription):
-    armor: int = 0
-
+class KnowingIsHalfTheBattle(OffhandInscription):
     id = ItemUpgrade.KnowingIsHalfTheBattle
-    target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusCasting,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusCasting, ModifierType.Arg2, 5, 5)
-    
+    armor: int = 5
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusCasting,
+            target="armor",
+            fixed_value=5,
+            value_getter=property_value(
+                ArmorPlusCasting,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+        
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_CASTING_BYTES, "(while casting)"))
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x8C, 0x5D, 0x1, 0x0]), f"Knowing Is Half The Battle")
     
 @dataclass(eq=False)
-class LifeIsPain(Inscription):
-    armor: int = 0
-    health: int = 0
-
+class LifeIsPain(OffhandInscription):
     id = ItemUpgrade.LifeIsPain
-    target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlus,
-        ModifierIdentifier.HealthMinus,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlus, ModifierType.Arg2, 4, 5)
+    armor: int = 5
+    health: int = 20
 
-
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlus,
+            target="armor",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                ArmorPlus,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HealthMinus,
+            target="health",
+            fixed_value=20,
+            value_getter=property_value(
+                HealthMinus,
+                lambda prop: prop.health_reduction,
+            ),
+        ),
+    )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, abs(self.armor), "Armor"),
+            GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.HEALTH_BYTES, abs(self.health), "Health")
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)")
+       
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x88, 0x5D, 0x1, 0x0]), f"Life Is Pain")
     
 @dataclass(eq=False)
-class LiveForToday(Inscription):
-    energy: int = 0
-    energy_regen: int = 0
-
+class LiveForToday(OffhandInscription):
     id = ItemUpgrade.LiveForToday
-    target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.EnergyPlus,
-        ModifierIdentifier.EnergyRegeneration,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.EnergyPlus, ModifierType.Arg2, 10, 15)
+    energy: int = 15
+    energy_regeneration: int = -1
+    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.EnergyPlus,
+            target="energy",
+            min_value=10,
+            max_value=15,
+            value_getter=property_value(
+                EnergyPlus,
+                lambda prop: prop.energy,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.EnergyRegeneration,
+            target="energy_regeneration",
+            fixed_value=-1,
+            value_getter=property_value(
+                EnergyRegeneration,
+                lambda prop: prop.energy_regeneration,
+            ),
+        ),
+    )
 
-
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ENERGY_BYTES, self.energy, "Energy"),
+            GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.ENERGY_REGEN_BYTES, abs(self.energy_regeneration), "Energy regeneration")
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x91, 0x5D, 0x1, 0x0]), f"Live For Today")
     
 @dataclass(eq=False)
-class ManForAllSeasons(Inscription):
-    armor: int = 0
-
+class ManForAllSeasons(OffhandInscription):
     id = ItemUpgrade.ManForAllSeasons
-    target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsElemental,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusVsElemental, ModifierType.Arg2, 4, 5)
+    armor: int = 5
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsElemental,
+            target="armor",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                ArmorPlusVsElemental,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor"), GWEncoded._dull_parenthesized(GWEncoded.VS_ELEMENTAL_DAMAGE_BYTES, "(vs. elemental damage)"), "(vs. elemental damage)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x89, 0x5D, 0x1, 0x0]), f"Man For All Seasons")
     
 @dataclass(eq=False)
-class MightMakesRight(Inscription):
-    armor: int = 0
-
+class MightMakesRight(OffhandInscription):
     id = ItemUpgrade.MightMakesRight
-    target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusAttacking,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusAttacking, ModifierType.Arg2, 4, 5)
+    armor: int = 5
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusAttacking,
+            target="armor",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                ArmorPlusAttacking,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor"), GWEncoded._dull_parenthesized(bytes([0xB4, 0xA, 0x1, 0x0]), "(while attacking)"))
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x8B, 0x5D, 0x1, 0x0]), f"Might Makes Right")
     
 @dataclass(eq=False)
-class SerenityNow(Inscription):
-    chance: int = 0
-
+class SerenityNow(OffhandInscription):
     id = ItemUpgrade.SerenityNow
-    target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.HalvesSkillRechargeGeneral,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesSkillRechargeGeneral, ModifierType.Arg1, 7, 10)
+    chance: int = 10
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeGeneral,
+            target="chance",
+            min_value=7,
+            max_value=10,
+            value_getter=property_value(
+                HalvesSkillRechargeGeneral,
+                lambda prop: prop.chance,
+            ),
+        ),
+    )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.HALVES_RECHARGE_BYTES]), "Halves skill recharge of spells"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x92, 0x5D, 0x1, 0x0]), f"Serenity Now")
     
 @dataclass(eq=False)
-class SurvivalOfTheFittest(Inscription):
-    armor: int = 0
-
+class SurvivalOfTheFittest(OffhandInscription):
     id = ItemUpgrade.SurvivalOfTheFittest
-    target_item_type = ItemType.Offhand
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsPhysical,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusVsPhysical, ModifierType.Arg2, 4, 5)
-
+    armor: int = 5
     
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsPhysical,
+            target="armor",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                ArmorPlusVsPhysical,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ARMOR_BYTES, self.armor, "Armor"), GWEncoded._dull_parenthesized(GWEncoded.VS_PHYSICAL_DAMAGE_BYTES, "(vs. physical damage)"), "(vs. physical damage)")    
+   
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x8A, 0x5D, 0x1, 0x0]), f"Survival Of The Fittest")
 
@@ -1408,152 +3502,271 @@ class SurvivalOfTheFittest(Inscription):
 #region Weapon
 
 @dataclass(eq=False)
-class BrawnOverBrains(Inscription):
-    damage_increase: int = 0
-    energy: int = 0
-
+class BrawnOverBrains(WeaponInscription):
     id = ItemUpgrade.BrawnOverBrains
-    target_item_type = ItemType.Weapon
-    property_identifiers = [
-        ModifierIdentifier.DamagePlusPercent,
-        ModifierIdentifier.EnergyMinus,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.DamagePlusPercent, ModifierType.Arg2, 14, 15)
+    damage_increase: int = 15
+    energy: int = 5
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusPercent,
+            target="damage_increase",
+            min_value=14,
+            max_value=15,
+            value_getter=property_value(
+                DamagePlusPercent,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.EnergyMinus,
+            target="energy",
+            fixed_value=5,
+            value_getter=property_value(
+                EnergyMinus,
+                lambda prop: prop.energy,
+            ),
+        ),
+    )
 
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._bonus_plus_percent(self.get_text_color(), GWEncoded.DAMAGE_BYTES, self.damage_increase, "Damage"),
+            GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.ENERGY_BYTES, abs(self.energy), "Energy")
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)")
+    
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xAE, 0x5D, 0x1, 0x0]), f"Brawn Over Brains")
         
 @dataclass(eq=False)
-class DanceWithDeath(Inscription):
-    damage_increase: int = 0
-
+class DanceWithDeath(WeaponInscription):
     id = ItemUpgrade.DanceWithDeath
-    target_item_type = ItemType.Weapon
-    property_identifiers = [
-        ModifierIdentifier.DamagePlusStance,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.DamagePlusStance, ModifierType.Arg2, 10, 15)
+    damage_increase: int = 15
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusStance,
+            target="damage_increase",
+            min_value=10,
+            max_value=15,
+            value_getter=property_value(
+                DamagePlusStance,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_percent(self.get_text_color(), GWEncoded.DAMAGE_BYTES, self.damage_increase, "Damage"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_IN_A_STANCE_BYTES, "(while in a Stance)"), "(while in a Stance)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xAD, 0x5D, 0x1, 0x0]), f"Dance With Death")
          
 @dataclass(eq=False)
-class DontFearTheReaper(Inscription):
-    damage_increase: int = 0
-
+class DontFearTheReaper(WeaponInscription):
     id = ItemUpgrade.DontFearTheReaper
-    target_item_type = ItemType.Weapon
-    property_identifiers = [
-        ModifierIdentifier.DamagePlusHexed,
-    ]    
-    modifier_range = ModifierRange(ModifierIdentifier.DamagePlusHexed, ModifierType.Arg2, 10, 20)
+    damage_increase: int = 15
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusHexed,
+            target="damage_increase",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusHexed,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_percent(self.get_text_color(), GWEncoded.DAMAGE_BYTES, self.damage_increase, "Damage"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_HEXED_BYTES, "(while Hexed)"), "(while Hexed)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xAC, 0x5D, 0x1, 0x0]), f"Dont Fear The Reaper")
     
 @dataclass(eq=False)
-class DontThinkTwice(Inscription):
-    chance: int = 0
-
+class DontThinkTwice(WeaponInscription):
     id = ItemUpgrade.DontThinkTwice
-    target_item_type = ItemType.Weapon
-    property_identifiers = [
-        ModifierIdentifier.HalvesCastingTimeGeneral,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesCastingTimeGeneral, ModifierType.Arg1, 5, 10)
+    chance: int = 10
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeGeneral,
+            target="chance",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                HalvesCastingTimeGeneral,
+                lambda prop: prop.chance,
+            ),
+        ),
+    )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.HALVES_CASTING_BYTES]), "Halves casting time of spells"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xB0, 0x5D, 0x1, 0x0]), f"Dont Think Twice")
     
 @dataclass(eq=False)
-class GuidedByFate(Inscription):
-    damage_increase: int = 0
-
+class GuidedByFate(WeaponInscription):
     id = ItemUpgrade.GuidedByFate
-    target_item_type = ItemType.Weapon
-    property_identifiers = [
-        ModifierIdentifier.DamagePlusEnchanted,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.DamagePlusEnchanted, ModifierType.Arg2, 10, 15)
+    damage_increase: int = 15
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusEnchanted,
+            target="damage_increase",
+            min_value=10,
+            max_value=15,
+            value_getter=property_value(
+                DamagePlusEnchanted,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+     )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_percent(self.get_text_color(), GWEncoded.DAMAGE_BYTES, self.damage_increase, "Damage"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_ENCHANTED_BYTES, "(while Enchanted)"), "(while Enchanted)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xA9, 0x5D, 0x1, 0x0]), f"Guided By Fate")
     
 @dataclass(eq=False)
-class StrengthAndHonor(Inscription):
-    damage_increase: int = 0
-    health_threshold: int = 0
-
+class StrengthAndHonor(WeaponInscription):
     id = ItemUpgrade.StrengthAndHonor
-    target_item_type = ItemType.Weapon
-    property_identifiers = [
-        ModifierIdentifier.DamagePlusWhileAbove,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.DamagePlusWhileAbove, ModifierType.Arg2, 10, 15)
-    max_modifier_values = {
-        ModifierIdentifier.DamagePlusWhileAbove: (50, 15),
-    }
+    damage_increase: int = 15
+    health_threshold: int = 50
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusWhileAbove,
+            target="damage_increase",
+            min_value=10,
+            max_value=15,
+            value_getter=property_value(
+                DamagePlusWhileAbove,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusWhileAbove,
+            target="health_threshold",
+            fixed_value=50,
+            value_getter=property_value(
+                DamagePlusWhileAbove,
+                lambda prop: prop.health_threshold,
+            ),
+        ),
+    )
 
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_percent(self.get_text_color(), GWEncoded.DAMAGE_BYTES, self.damage_increase, "Damage"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_HEALTH_ABOVE_BYTES, f"(while Health is above {self.health_threshold}%)"), f"(while Health is above {self.health_threshold}%)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xAA, 0x5D, 0x1, 0x0]), f"Strength And Honor")
     
 @dataclass(eq=False)
-class ToThePain(Inscription):
-    damage_increase: int = 0
-    armor: int = 0
-
+class ToThePain(WeaponInscription):
     id = ItemUpgrade.ToThePain
-    target_item_type = ItemType.Weapon
-    property_identifiers = [
-        ModifierIdentifier.DamagePlusPercent,
-        ModifierIdentifier.ArmorMinusAttacking
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.DamagePlusPercent, ModifierType.Arg2, 14, 15)
+    damage_increase: int = 15
+    armor: int = 10
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusPercent,
+            target="damage_increase",
+            min_value=14,
+            max_value=15,
+            value_getter=property_value(
+                DamagePlusPercent,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorMinusAttacking,
+            target="armor",
+            fixed_value=10,
+            value_getter=property_value(
+                ArmorMinusAttacking,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
 
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._bonus_plus_percent(self.get_text_color(), GWEncoded.DAMAGE_BYTES, self.damage_increase, "Damage"),
+            GWEncoded._encoded(
+                bytes([*self.get_text_color(), *GWEncoded.MINUS_NUM_TEMPLATE, *GWEncoded.ARMOR_BYTES, 0x1, 0x1, self.armor, 0x1, 0x1, 0x0, *GWEncoded.WHILE_ATTACKING_BYTES]),
+                f"Armor -{self.armor} (while attacking)",
+            ),
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xAF, 0x5D, 0x1, 0x0]), f"To The Pain")
     
 @dataclass(eq=False)
-class TooMuchInformation(Inscription):
-    damage_increase: int = 0
-
+class TooMuchInformation(WeaponInscription):
     id = ItemUpgrade.TooMuchInformation
-    target_item_type = ItemType.Weapon
-    property_identifiers = [
-        ModifierIdentifier.DamagePlusVsHexed,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.DamagePlusVsHexed, ModifierType.Arg2, 10, 15)
+    damage_increase: int = 15
 
-    
+    upgrade_info = (
+         ranged(
+            identifier=ModifierIdentifier.DamagePlusVsHexed,
+            target="damage_increase",
+            min_value=10,
+            max_value=15,
+            value_getter=property_value(
+                DamagePlusVsHexed,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_percent(self.get_text_color(), GWEncoded.DAMAGE_BYTES, self.damage_increase, "Damage"), GWEncoded._dull_parenthesized(GWEncoded.VS_HEXED_FOES_BYTES, "(vs. Hexed foes)"), "(vs. Hexed foes)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xA8, 0x5D, 0x1, 0x0]), f"Too Much Information")
     
 @dataclass(eq=False)
-class VengeanceIsMine(Inscription):
-    damage_increase: int = 0
-    health_threshold: int = 0
-
+class VengeanceIsMine(WeaponInscription):
     id = ItemUpgrade.VengeanceIsMine
-    target_item_type = ItemType.Weapon
-    property_identifiers = [
-        ModifierIdentifier.DamagePlusWhileBelow,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.DamagePlusWhileBelow, ModifierType.Arg2, 10, 20)
-    max_modifier_values = {
-        ModifierIdentifier.DamagePlusWhileBelow: (50, 20),
-    }
+    damage_increase: int = 20
+    health_threshold: int = 50
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusWhileBelow,
+            target="damage_increase",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                DamagePlusWhileBelow,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.DamagePlusWhileBelow,
+            target="health_threshold",
+            fixed_value=50,
+            value_getter=property_value(
+                DamagePlusWhileBelow,
+                lambda prop: prop.health_threshold,
+            ),
+        ),
+    )
 
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_percent(self.get_text_color(), GWEncoded.DAMAGE_BYTES, self.damage_increase, "Damage"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_HEALTH_BELOW_BYTES, f"(while Health is below {self.health_threshold}%)"), f"(while Health is below {self.health_threshold}%)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xAB, 0x5D, 0x1, 0x0]), f"Vengeance Is Mine")
@@ -1562,31 +3775,48 @@ class VengeanceIsMine(Inscription):
 
 #region MartialWeapon
 @dataclass(eq=False)
-class IHaveThePower(Inscription):
-    energy: int = 0
-
+class IHaveThePower(MartialWeaponInscription):
     id = ItemUpgrade.IHaveThePower
-    target_item_type = ItemType.MartialWeapon
-    property_identifiers = [
-        ModifierIdentifier.EnergyPlus,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.EnergyPlus, ModifierType.Arg2, 5, 5)
+    energy: int = 5
 
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.EnergyPlus,
+            target="energy",
+            fixed_value=5,
+            value_getter=property_value(
+                EnergyPlus,
+                lambda prop: prop.energy,
+            ),
+        ),
+    )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ENERGY_BYTES, self.energy, "Energy")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x72, 0x5D, 0x1, 0x0]), f"I Have The Power")
     
 @dataclass(eq=False)
-class LetTheMemoryLiveAgain(Inscription):
-    chance: int = 0
-
+class LetTheMemoryLiveAgain(MartialWeaponInscription):
     id = ItemUpgrade.LetTheMemoryLiveAgain
-    target_item_type = ItemType.MartialWeapon
-    property_identifiers = [
-        ModifierIdentifier.HalvesSkillRechargeGeneral,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesSkillRechargeGeneral, ModifierType.Arg1, 5, 10)
+    chance: int = 10
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeGeneral,
+            target="chance",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                HalvesSkillRechargeGeneral,
+                lambda prop: prop.chance,
+            ),
+        ),
+    )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.HALVES_RECHARGE_BYTES]), "Halves skill recharge of spells"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x73, 0x5D, 0x1, 0x0]), f"Let The Memory Live Again")
@@ -1595,335 +3825,511 @@ class LetTheMemoryLiveAgain(Inscription):
 
 #region OffhandOrShield
 @dataclass(eq=False)
-class CastOutTheUnclean(Inscription):
-    condition: Ailment | None = None
-
+class CastOutTheUnclean(ReduceConditionDurationInscription):
     id = ItemUpgrade.CastOutTheUnclean
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ReduceConditionDuration,
-    ]
+    condition = Reduced_Ailment.Disease
 
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionDuration,
+            target="condition",
+            fixed_value=Reduced_Ailment.Disease,
+            value_getter=property_value(
+                ReduceConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+     )
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x83, 0x5D, 0x1, 0x0]), f"Cast Out The Unclean")
     
 @dataclass(eq=False)
-class FearCutsDeeper(Inscription):
-    condition: Ailment | None = None
-
+class FearCutsDeeper(ReduceConditionDurationInscription):
     id = ItemUpgrade.FearCutsDeeper
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ReduceConditionDuration,
-    ]
-
+    condition = Reduced_Ailment.Bleeding
+    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionDuration,
+            target="condition",
+            fixed_value=Reduced_Ailment.Bleeding,
+            value_getter=property_value(
+                ReduceConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+     )
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x7F, 0x5D, 0x1, 0x0]), f"Fear Cuts Deeper")
     
 @dataclass(eq=False)
-class ICanSeeClearlyNow(Inscription):
-    condition: Ailment | None = None
-
+class ICanSeeClearlyNow(ReduceConditionDurationInscription):
     id = ItemUpgrade.ICanSeeClearlyNow
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ReduceConditionDuration,   
-    ]
-
+    condition = Reduced_Ailment.Blind
+    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionDuration,
+            target="condition",
+            fixed_value=Reduced_Ailment.Blind,
+            value_getter=property_value(
+                ReduceConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+     )
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x80, 0x5D, 0x1, 0x0]), f"I Can See Clearly Now")
     
 @dataclass(eq=False)
-class LeafOnTheWind(Inscription):
-    armor: int = 0
-    damage_type: DamageType | None = None
-
+class LeafOnTheWind(ArmorVsDamageTypeInscription):
     id = ItemUpgrade.LeafOnTheWind
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsDamage,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusVsDamage, ModifierType.Arg2, 5, 10)
-    max_modifier_values = {
-        ModifierIdentifier.ArmorPlusVsDamage: (3, 10),
-    }
-
-
+    damage_type = DamageType.Cold
     
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="damage_type",
+            fixed_value=DamageType.Cold,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.damage_type,
+            ),
+        ),
+     )
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x75, 0x5D, 0x1, 0x0]), f"Leaf On The Wind")
     
 @dataclass(eq=False)
-class LikeARollingStone(Inscription):
-    armor: int = 0
-    damage_type: DamageType | None = None
-
+class LikeARollingStone(ArmorVsDamageTypeInscription):
     id = ItemUpgrade.LikeARollingStone
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsDamage,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusVsDamage, ModifierType.Arg2, 5, 10)
-    max_modifier_values = {
-        ModifierIdentifier.ArmorPlusVsDamage: (11, 10),
-    }
+    damage_type = DamageType.Earth
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="damage_type",
+            fixed_value=DamageType.Earth,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.damage_type,
+            ),
+        ),
+     )
 
-    
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x76, 0x5D, 0x1, 0x0]), f"Like A Rolling Stone")
     
 @dataclass(eq=False)
-class LuckOfTheDraw(Inscription):
-    damage_reduction: int = 0
-    chance: int = 0
-
+class LuckOfTheDraw(OffhandOrShieldInscription):
     id = ItemUpgrade.LuckOfTheDraw
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ReceiveLessDamage,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ReceiveLessDamage, ModifierType.Arg1, 11, 20)
-    max_modifier_values = {
-        ModifierIdentifier.ReceiveLessDamage: (20, 5),
-    }
+    damage_reduction: int = 5
+    chance: int = 20
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ReceiveLessDamage,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                ReceiveLessDamage,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ReceiveLessDamage,
+            target="damage_reduction",
+            fixed_value=5,
+            value_getter=property_value(
+                ReceiveLessDamage,
+                lambda prop: prop.damage_reduction,
+            ),
+        ),
+     )
 
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes(), f"Received damage -{self.damage_reduction} (Chance: {self.chance}%)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x7B, 0x5D, 0x1, 0x0]), f"Luck Of The Draw")
     
 @dataclass(eq=False)
-class MasterOfMyDomain(Inscription):
-    chance: int = 0
-    attribute_level: int = 0
-
+class MasterOfMyDomain(OffhandOrShieldInscription):
     id = ItemUpgrade.MasterOfMyDomain
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.AttributePlusOneItem,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.AttributePlusOneItem, ModifierType.Arg1, 11, 20)
+    chance: int = 20
+    attribute_level: int = 1
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOneItem,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOneItem,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOneItem,
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOneItem,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+     )
 
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.ITEM_ATTRIBUTE_PLUS_ONE_BYTES, self.attribute_level]), "Item's attribute +1"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xA7, 0x5D, 0x1, 0x0]), f"Master Of My Domain")
     
 @dataclass(eq=False)
-class NotTheFace(Inscription):
-    armor: int = 0
-    damage_type: DamageType | None = None
-
+class NotTheFace(ArmorVsDamageTypeInscription):
     id = ItemUpgrade.NotTheFace
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsDamage
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusVsDamage, ModifierType.Arg2, 5, 10)
-    max_modifier_values = {
-        ModifierIdentifier.ArmorPlusVsDamage: (0, 10),
-    }
+    damage_type = DamageType.Blunt
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="damage_type",
+            fixed_value=DamageType.Blunt,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.damage_type,
+            ),
+        ),
+     )
 
-    
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x74, 0x5D, 0x1, 0x0]), f"Not The Face")
     
 @dataclass(eq=False)
-class NothingToFear(Inscription):
-    damage_reduction: int = 0
-
+class NothingToFear(OffhandOrShieldInscription):
     id = ItemUpgrade.NothingToFear
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ReceiveLessPhysDamageHexed,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ReceiveLessPhysDamageHexed, ModifierType.Arg2, 1, 3)
+    damage_reduction: int = 3
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ReceiveLessPhysDamageHexed,
+            target="damage_reduction",
+            min_value=1,
+            max_value=3,
+            value_getter=property_value(
+                ReceiveLessPhysDamageHexed,
+                lambda prop: prop.damage_reduction,
+            ),
+        ),
+     )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_minus_num(self.get_text_color(), bytes([0x1, 0x81, 0x4F, 0x5D, 0x1, 0x0]), self.damage_reduction, "Received physical damage"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_HEXED_BYTES, "(while Hexed)"), "(while Hexed)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x7D, 0x5D, 0x1, 0x0]), f"Nothing To Fear")
     
 @dataclass(eq=False)
-class OnlyTheStrongSurvive(Inscription):
-    condition: Ailment | None = None
-
+class OnlyTheStrongSurvive(ReduceConditionDurationInscription):
     id = ItemUpgrade.OnlyTheStrongSurvive
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ReduceConditionDuration,
-    ]
+    condition = Reduced_Ailment.Weakness
 
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionDuration,
+            target="condition",
+            fixed_value=Reduced_Ailment.Weakness,
+            value_getter=property_value(
+                ReduceConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+     )
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x86, 0x5D, 0x1, 0x0]), f"Only The Strong Survive")
     
 @dataclass(eq=False)
-class PureOfHeart(Inscription):
-    condition: Ailment | None = None
-
+class PureOfHeart(ReduceConditionDurationInscription):
     id = ItemUpgrade.PureOfHeart
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ReduceConditionDuration,
-    ]
+    condition = Reduced_Ailment.Poison
 
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionDuration,
+            target="condition",
+            fixed_value=Reduced_Ailment.Poison,
+            value_getter=property_value(
+                ReduceConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+     )
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x84, 0x5D, 0x1, 0x0]), f"Pure Of Heart")
     
 @dataclass(eq=False)
-class RidersOnTheStorm(Inscription):
-    armor: int = 0
-    damage_type: DamageType | None = None
-
+class RidersOnTheStorm(ArmorVsDamageTypeInscription):
     id = ItemUpgrade.RidersOnTheStorm
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsDamage,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusVsDamage, ModifierType.Arg2, 5, 10)
-    max_modifier_values = {
-        ModifierIdentifier.ArmorPlusVsDamage: (4, 10),
-    }
-
-
+    damage_type = DamageType.Lightning
+    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="damage_type",
+            fixed_value=DamageType.Lightning,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.damage_type,
+             ),
+        ),
+     )
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x77, 0x5D, 0x1, 0x0]), f"Riders On The Storm")
     
 @dataclass(eq=False)
-class RunForYourLife(Inscription):
-    damage_reduction: int = 0
-
+class RunForYourLife(OffhandOrShieldInscription):
     id = ItemUpgrade.RunForYourLife
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ReceiveLessPhysDamageStance,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ReceiveLessPhysDamageStance, ModifierType.Arg2, 1, 2)
+    damage_reduction: int = 2
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ReceiveLessPhysDamageStance,
+            target="damage_reduction",
+            min_value=1,
+            max_value=2,
+            value_getter=property_value(
+                ReceiveLessPhysDamageStance,
+                lambda prop: prop.damage_reduction,
+            ),
+        ),
+     )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_minus_num(self.get_text_color(), bytes([0x1, 0x81, 0x4F, 0x5D, 0x1, 0x0]), self.damage_reduction, "Received physical damage"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_IN_A_STANCE_BYTES, "(while in a Stance)"), "(while in a Stance)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x7E, 0x5D, 0x1, 0x0]), f"Run For Your Life")  
     
 @dataclass(eq=False)
-class ShelteredByFaith(Inscription):
-    damage_reduction: int = 0
-
+class ShelteredByFaith(OffhandOrShieldInscription):
     id = ItemUpgrade.ShelteredByFaith
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ReceiveLessPhysDamageEnchanted,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ReceiveLessPhysDamageEnchanted, ModifierType.Arg2, 1, 2)
+    damage_reduction: int = 2
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ReceiveLessPhysDamageEnchanted,
+            target="damage_reduction",
+            min_value=1,
+            max_value=2,
+            value_getter=property_value(
+                ReceiveLessPhysDamageEnchanted,
+                lambda prop: prop.damage_reduction,
+            ),
+        ),
+     )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_minus_num(self.get_text_color(), bytes([0x1, 0x81, 0x4F, 0x5D, 0x1, 0x0]), self.damage_reduction, "Received physical damage"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_ENCHANTED_BYTES, "(while Enchanted)"), "(while Enchanted)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x7C, 0x5D, 0x1, 0x0]), f"Sheltered By Faith")
     
 @dataclass(eq=False)
-class SleepNowInTheFire(Inscription):
-    armor: int = 0
-    damage_type: DamageType | None = None
-
+class SleepNowInTheFire(ArmorVsDamageTypeInscription):
     id = ItemUpgrade.SleepNowInTheFire
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsDamage,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusVsDamage, ModifierType.Arg2, 5, 10)
-    max_modifier_values = {
-        ModifierIdentifier.ArmorPlusVsDamage: (5, 10),
-    }
-
-
+    damage_type = DamageType.Fire
     
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="damage_type",
+            fixed_value=DamageType.Fire,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.damage_type,
+            ),
+        ),
+     )
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x78, 0x5D, 0x1, 0x0]), f"Sleep Now In The Fire")
     
 @dataclass(eq=False)
-class SoundnessOfMind(Inscription):
-    condition: Ailment | None = None
-
+class SoundnessOfMind(ReduceConditionDurationInscription):
     id = ItemUpgrade.SoundnessOfMind
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ReduceConditionDuration,
-    ]
-
+    condition = Reduced_Ailment.Dazed
+    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionDuration,
+            target="condition",
+            fixed_value=Reduced_Ailment.Dazed,
+            value_getter=property_value(
+                ReduceConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+     )
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x85, 0x5D, 0x1, 0x0]), f"Soundness Of Mind")
     
 @dataclass(eq=False)
-class StrengthOfBody(Inscription):
-    condition: Ailment | None = None
-
+class StrengthOfBody(ReduceConditionDurationInscription):
     id = ItemUpgrade.StrengthOfBody
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ReduceConditionDuration,
-    ]
-
+    condition = Reduced_Ailment.Deep_Wound
+    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionDuration,
+            target="condition",
+            fixed_value=Reduced_Ailment.Deep_Wound,
+            value_getter=property_value(
+                ReduceConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+     )
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x82, 0x5D, 0x1, 0x0]), f"Strength Of Body")
     
 @dataclass(eq=False)
-class SwiftAsTheWind(Inscription):
-    condition: Ailment | None = None
-
+class SwiftAsTheWind(ReduceConditionDurationInscription):
     id = ItemUpgrade.SwiftAsTheWind
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ReduceConditionDuration,
-    ]
+    condition = Reduced_Ailment.Crippled
 
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionDuration,
+            target="condition",
+            fixed_value=Reduced_Ailment.Crippled,
+            value_getter=property_value(
+                ReduceConditionDuration,
+                lambda prop: prop.condition,
+            ),
+        ),
+     )
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x81, 0x5D, 0x1, 0x0]), f"Swift As The Wind")
 
 @dataclass(eq=False)
-class TheRiddleOfSteel(Inscription):
-    armor: int = 0
-    damage_type: DamageType | None = None
-
+class TheRiddleOfSteel(ArmorVsDamageTypeInscription):
     id = ItemUpgrade.TheRiddleOfSteel
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsDamage,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusVsDamage, ModifierType.Arg2, 5, 10)
-    max_modifier_values = {
-        ModifierIdentifier.ArmorPlusVsDamage: (2, 10),
-    }
-
-
+    damage_type = DamageType.Slashing
+    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="damage_type",
+            fixed_value=DamageType.Slashing,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.damage_type,
+            ),
+        ),
+     )
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x7A, 0x5D, 0x1, 0x0]), f"The Riddle Of Steel")
     
 @dataclass(eq=False)
-class ThroughThickAndThin(Inscription):
-    armor: int = 0
-    damage_type: DamageType | None = None
-
+class ThroughThickAndThin(ArmorVsDamageTypeInscription):
     id = ItemUpgrade.ThroughThickAndThin
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsDamage,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusVsDamage, ModifierType.Arg2, 5, 10)
-    max_modifier_values = {
-        ModifierIdentifier.ArmorPlusVsDamage: (1, 10),
-    }
-
-
+    damage_type = DamageType.Piercing
+    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="damage_type",
+            fixed_value=DamageType.Piercing,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.damage_type,
+            ),
+        ),
+     )
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0x79, 0x5D, 0x1, 0x0]), f"Through Thick And Thin")
@@ -1932,30 +4338,48 @@ class ThroughThickAndThin(Inscription):
 
 #region EquippableItem
 @dataclass(eq=False)
-class MeasureForMeasure(Inscription):
-    highly_salvageable: bool = False
-
+class MeasureForMeasure(EquippableItemInscription):
     id = ItemUpgrade.MeasureForMeasure
-    target_item_type = ItemType.EquippableItem
-    property_identifiers = [
-        ModifierIdentifier.HighlySalvageable,
-    ]
+    highly_salvageable: bool = True
+    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.HighlySalvageable,
+            target="highly_salvageable",
+            fixed_value=True,
+            value_getter=property_value(
+                HighlySalvageable,
+                lambda _: True,
+            ),
+        ),
+     )
 
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes([*self.get_text_color(), *GWEncoded.HIGHLY_SALVAGEABLE_BYTES]), "Highly salvageable")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x81, 0x7C, 0x1, 0x0]), f"Measure For Measure")
         
 @dataclass(eq=False)
-class ShowMeTheMoney(Inscription):
-    improved_sale_value: bool = False
-
+class ShowMeTheMoney(EquippableItemInscription):
     id = ItemUpgrade.ShowMeTheMoney
-    target_item_type = ItemType.EquippableItem
-    property_identifiers = [
-        ModifierIdentifier.IncreasedSaleValue,
-    ]    
+    improved_sale_value: bool = True
 
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.IncreasedSaleValue,
+            target="improved_sale_value",
+            fixed_value=True,
+            value_getter=property_value(
+                IncreasedSaleValue,
+                lambda _: True,
+            ),
+        ),
+     )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes([*self.get_text_color(), *GWEncoded.IMPROVED_SALE_VALUE_BYTES]), "Improved sale value")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x80, 0x7C, 0x1, 0x0]), f"Show Me The Money")
 
@@ -1963,149 +4387,205 @@ class ShowMeTheMoney(Inscription):
 
 #region SpellcastingWeapon
 @dataclass(eq=False)
-class AptitudeNotAttitude(Inscription):
-    chance: int = 0
-
+class AptitudeNotAttitude(SpellcastingWeaponInscription):
     id = ItemUpgrade.AptitudeNotAttitude
-    target_item_type = ItemType.SpellcastingWeapon
-    property_identifiers = [
-        ModifierIdentifier.HalvesCastingTimeItemAttribute,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesCastingTimeItemAttribute, ModifierType.Arg1, 10, 20)
-
+    chance: int = 20
     
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeItemAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeItemAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+     )
+    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._encoded(bytes([*self.get_text_color(), *GWEncoded.HALVES_CASTING_ITEM_ATTRIBUTE_BYTES]), "Halves casting time on spells of item's attribute"), GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xB2, 0x5D, 0x1, 0x0]), f"Aptitude Not Attitude")
     
 @dataclass(eq=False)
-class DontCallItAComeback(Inscription):
-    energy: int = 0
-    health_threshold: int = 0
-
+class DontCallItAComeback(SpellcastingWeaponInscription):
     id = ItemUpgrade.DontCallItAComeback
-    target_item_type = ItemType.SpellcastingWeapon
-    property_identifiers = [
-        ModifierIdentifier.EnergyPlusWhileBelow,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.EnergyPlusWhileBelow, ModifierType.Arg2, 5, 7)
-    max_modifier_values = {
-        ModifierIdentifier.EnergyPlusWhileBelow: (50, 7),
-    }
+    energy: int = 7
+    health_threshold: int = 50
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.EnergyPlusWhileBelow,
+            target="energy",
+            min_value=5,
+            max_value=7,
+            value_getter=property_value(
+                EnergyPlusWhileBelow,
+                lambda prop: prop.energy,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.EnergyPlusWhileBelow,
+            target="health_threshold",
+            fixed_value=50,
+            value_getter=property_value(
+                EnergyPlusWhileBelow,
+                lambda prop: prop.health_threshold,
+            ),
+        ),
+     )
 
-    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ENERGY_BYTES, self.energy, "Energy"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_HEALTH_BELOW_BYTES, f"(while Health is below {self.health_threshold}%)"), f"(while Health is below {self.health_threshold}%)")
+        
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xB6, 0x5D, 0x1, 0x0]), f"Don't Call It A Comeback")
     
 @dataclass(eq=False)
-class HaleAndHearty(Inscription):
-    energy: int = 0
-    health_threshold: int = 0
-
+class HaleAndHearty(SpellcastingWeaponInscription):
     id = ItemUpgrade.HaleAndHearty
-    target_item_type = ItemType.SpellcastingWeapon
-    property_identifiers = [
-        ModifierIdentifier.EnergyPlusWhileAbove,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.EnergyPlusWhileAbove, ModifierType.Arg2, 4, 5)
-    max_modifier_values = {
-        ModifierIdentifier.EnergyPlusWhileAbove: (50, 5),
-    }
+    energy: int = 5
+    health_threshold: int = 50
+    
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.EnergyPlusWhileAbove,
+            target="energy",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                EnergyPlusWhileAbove,
+                lambda prop: prop.energy,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.EnergyPlusWhileAbove,
+            target="health_threshold",
+            fixed_value=50,
+            value_getter=property_value(
+                EnergyPlusWhileAbove,
+                lambda prop: prop.health_threshold,
+            ),
+        ),
+     )
 
-
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ENERGY_BYTES, self.energy, "Energy"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_HEALTH_ABOVE_BYTES, f"(while Health is above {self.health_threshold}%)"), f"(while Health is above {self.health_threshold}%)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xB5, 0x5D, 0x1, 0x0]), f"Hale And Hearty")
     
 @dataclass(eq=False)
-class HaveFaith(Inscription):
-    energy: int = 0
-
+class HaveFaith(SpellcastingWeaponInscription):
     id = ItemUpgrade.HaveFaith
-    target_item_type = ItemType.SpellcastingWeapon
-    property_identifiers = [
-        ModifierIdentifier.EnergyPlusEnchanted,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.EnergyPlusEnchanted, ModifierType.Arg2, 4, 5)
+    energy: int = 5
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.EnergyPlusEnchanted,
+            target="energy",
+            min_value=4,
+            max_value=5,
+            value_getter=property_value(
+                EnergyPlusEnchanted,
+                lambda prop: prop.energy,
+            ),
+        ),
+     )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ENERGY_BYTES, self.energy, "Energy"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_ENCHANTED_BYTES, "(while Enchanted)"), "(while Enchanted)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xB4, 0x5D, 0x1, 0x0]), f"Have Faith")
     
 @dataclass(eq=False)
-class IAmSorrow(Inscription):
-    energy: int = 0
-
+class IAmSorrow(SpellcastingWeaponInscription):
     id = ItemUpgrade.IAmSorrow
-    target_item_type = ItemType.SpellcastingWeapon
-    property_identifiers = [
-        ModifierIdentifier.EnergyPlusHexed,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.EnergyPlusHexed, ModifierType.Arg2, 5, 7)
+    energy: int = 7
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.EnergyPlusHexed,
+            target="energy",
+            min_value=5,
+            max_value=7,
+            value_getter=property_value(
+                EnergyPlusHexed,
+                lambda prop: prop.energy,
+            ),
+        ),
+     )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ENERGY_BYTES, self.energy, "Energy"), GWEncoded._dull_parenthesized(GWEncoded.WHILE_HEXED_BYTES, "(while Hexed)"), "(while Hexed)")
+
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xB7, 0x5D, 0x1, 0x0]), f"I Am Sorrow")
     
 @dataclass(eq=False)
-class SeizeTheDay(Inscription):
-    energy: int = 0
-    energy_regen: int = 0
-
+class SeizeTheDay(SpellcastingWeaponInscription):
     id = ItemUpgrade.SeizeTheDay
-    target_item_type = ItemType.SpellcastingWeapon
-    property_identifiers = [
-        ModifierIdentifier.EnergyPlus,
-        ModifierIdentifier.EnergyRegeneration,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.EnergyPlus, ModifierType.Arg2, 10, 15)
+    energy: int = 15
+    energy_regeneration: int = -1
 
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.EnergyPlus,
+            target="energy",
+            min_value=10,
+            max_value=15,
+            value_getter=property_value(
+                EnergyPlus,
+                lambda prop: prop.energy,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.EnergyRegeneration,
+            target="energy_regeneration",
+            fixed_value=-1,
+            value_getter=property_value(
+                EnergyRegeneration,
+                lambda prop: prop.energy_regeneration,
+            ),
+        ),
+     )
 
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ENERGY_BYTES, self.energy, "Energy"),
+            GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.ENERGY_REGEN_BYTES, abs(self.energy_regeneration), "Energy regeneration")
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)")
     
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color() + GWEncoded.INSCRIPTION_STR1 + bytes([0x1, 0x81, 0xB3, 0x5D, 0x1, 0x0]), f"Seize The Day")
 
 #endregion SpellcastingWeapon
+
 #endregion Inscriptions
 
 #region Inherent (Old School)
 @dataclass(eq=False)
 class Inherent(Upgrade):
     mod_type = ItemUpgradeType.Inherent
-    id: ClassVar[ItemUpgrade] = ItemUpgrade.Inherent
-    target_item_type: ClassVar[ItemType]
-    modifier_range: ClassVar[Optional[ModifierRange]] = None
+    target_item_type: ItemType = ItemType.EquippableItem
 
     def __post_init__(self):
         super().__post_init__()
         object.__setattr__(self, "is_inherent", True)
     
-    def create_encoded_description(self) -> GWStringEncoded:
-        if not self.properties:
-            return GWStringEncoded(bytes(), f"[Inherent] No properties present. Thus no encoded description ({self.__class__.__name__})")
-        
-        parts = [prop.encoded_description for prop in self.properties.values() if prop.encoded_description]
-        return GWEncoded.combine_encoded_strings(parts, "no encoded description")
-
     @classmethod
     def has_id(cls, upgrade_id: ItemUpgradeId) -> bool:
         return False
-
-    @property
-    def is_maxed(self) -> bool:
-        if not self.properties or not self.modifier_range:
-            return True
-
-        prop = self._get_upgrade_property(self.modifier_range.modifierIdentifier)
-        if not prop:
-            return False
-
-        value = prop.modifier.arg1 if self.modifier_range.modifier_type == ModifierType.Arg1 else prop.modifier.arg2
-        return self.modifier_range.min_value <= value <= self.modifier_range.max_value
     
     def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(bytes(), f"Inherent: {Utils.humanize_string(self.__class__.__name__)}")
-    
+        return GWStringEncoded(bytes(), f"Inherent: {_humanize_identifier(self.__class__.__name__)}")
+
 #region Weapon
 @dataclass(eq=False)
 class DamagePlusWhileAboveUpgrade(Inherent, StrengthAndHonor):
@@ -2153,31 +4633,76 @@ class DamagePlusWhileBelowUpgrade(Inherent, VengeanceIsMine):
 
 @dataclass(eq=False)
 class VampiricStrengthUpgrade(Inherent):
-    damage_increase: int = 0
-    health_regeneration: int = 0
-
+    damage_increase: int = 15
+    health_regeneration: int = -1
     target_item_type = ItemType.Weapon
-    property_identifiers = [
-        ModifierIdentifier.DamagePlusPercent,
-        ModifierIdentifier.HealthRegeneneration,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.DamagePlusPercent, ModifierType.Arg2, 10, 15)
+        
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusPercent,
+            target="damage_increase",
+            min_value=10,
+            max_value=15,
+            value_getter=property_value(
+                DamagePlusPercent,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HealthRegeneneration,
+            target="health_regeneration",
+            fixed_value=-1,
+            value_getter=property_value(
+                HealthRegeneneration,
+                lambda prop: prop.health_regeneration,
+            ),
+        ),
+     )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._bonus_plus_percent(self.get_text_color(), GWEncoded.DAMAGE_BYTES, self.damage_increase, "Damage"),
+            GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.HEALTH_REGEN_BYTES, abs(self.health_regeneration), "Health regeneration")
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, "no encoded description")
     
 
 @dataclass(eq=False)
 class ZealousStrengthUpgrade(Inherent):
-    damage_increase: int = 0
-    energy_regeneration: int = 0
-
+    damage_increase: int = 15
+    energy_regeneration: int = -1
     target_item_type = ItemType.Weapon
-    property_identifiers = [
-        ModifierIdentifier.DamagePlusPercent,
-        ModifierIdentifier.EnergyRegeneration,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.DamagePlusPercent, ModifierType.Arg2, 10, 15)
     
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.DamagePlusPercent,
+            target="damage_increase",
+            min_value=10,
+            max_value=15,
+            value_getter=property_value(
+                DamagePlusPercent,
+                lambda prop: prop.damage_increase,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.EnergyRegeneration,
+            target="energy_regeneration",
+             fixed_value=-1,
+            value_getter=property_value(
+                EnergyRegeneration,
+                lambda prop: prop.energy_regeneration,
+            ),
+         ),
+     )
     
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._bonus_plus_percent(self.get_text_color(), GWEncoded.DAMAGE_BYTES, self.damage_increase, "Damage"),
+            GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.ENERGY_REGEN_BYTES, abs(self.energy_regeneration), "Energy regeneration")
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, "no encoded description")
     
 #endregion Weapon
 
@@ -2200,7 +4725,6 @@ class ArmorPlusEnchantedUpgrade(Inherent, FaithIsMyShield):
 @dataclass(eq=False)
 class HalvesSkillRechargeItemAttributeUpgrade(Inherent, ForgetMeNot):
     pass
-
 
 @dataclass(eq=False)
 class ArmorPlusAboveUpgrade(Inherent, HailToTheKing):
@@ -2272,19 +4796,755 @@ class HealthPlusEnchantedUpgrade(Inherent, OfDevotionUpgrade):
 
 @dataclass(eq=False)
 class AttributePlusOneUpgrade(Inherent):
-    chance: int = 0
+    chance: int = 20
     attribute: Attribute = Attribute.None_
-    attribute_level: int = 0
+    attribute_level: int = 1
+    target_item_type = ItemType.OffhandOrShield    
 
-    target_item_type = ItemType.OffhandOrShield
-    property_identifiers = [
-        ModifierIdentifier.AttributePlusOne,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.AttributePlusOne, ModifierType.Arg1, 11, 20)
+    def create_encoded_description(self) -> GWStringEncoded:
+        attribute_bytes = GWEncoded._attribute_bytes(self.attribute)
+        if attribute_bytes:
+            base = GWStringEncoded(bytes([*self.get_text_color(), 0x84, 0xA, 0xA, 0x1, *attribute_bytes, 0x1, 0x0, 0x1, 0x1, 0x1, self.attribute_level]), f"{GWEncoded._attribute_name(self.attribute)} +{self.attribute_level}")
+            clause_raw = bytes([0xC1, 0xA, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0])
+            
+            return GWEncoded._append_line_with_fallback(base, GWEncoded._dull_parenthesized(clause_raw, f"({self.chance}% chance while using skills)"), f"({self.chance}% chance while using skills)")
+        return GWStringEncoded(bytes(), f"{GWEncoded._attribute_name(self.attribute)} +1 ({self.chance}% chance while using skills)")
 
-    
 
-        
+@dataclass(eq=False)
+class DivineFavorPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.DivineFavor
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.DivineFavor,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HealingPrayersPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.HealingPrayers
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.HealingPrayers,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class SmitingPrayersPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.SmitingPrayers
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.SmitingPrayers,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class ProtectionPrayersPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.ProtectionPrayers
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.ProtectionPrayers,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class SoulReapingPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.SoulReaping
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.SoulReaping,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class BloodMagicPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.BloodMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.BloodMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class DeathMagicPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.DeathMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.DeathMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class CursesPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.Curses
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.Curses,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class FastCastingPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.FastCasting
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.FastCasting,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class IllusionMagicPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.IllusionMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.IllusionMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class DominationMagicPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.DominationMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.DominationMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class InspirationMagicPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.InspirationMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.InspirationMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class EnergyStoragePlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.EnergyStorage
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.EnergyStorage,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class AirMagicPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.AirMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.AirMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class EarthMagicPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.EarthMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.EarthMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class FireMagicPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.FireMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.FireMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class WaterMagicPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.WaterMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.WaterMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class SpawningPowerPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.SpawningPower
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.SpawningPower,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class CommuningPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.Communing
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.Communing,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class RestorationMagicPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.RestorationMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.RestorationMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class ChannelingMagicPlusOneUpgrade(AttributePlusOneUpgrade):
+    attribute = Attribute.ChannelingMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="chance",
+            min_value=11,
+            max_value=20,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne, 
+            target="attribute_level",
+            fixed_value=1,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute_level,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.AttributePlusOne,
+            target="attribute",
+            fixed_value=Attribute.ChannelingMagic,
+            value_getter=property_value(
+                AttributePlusOne,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )        
 
 @dataclass(eq=False)
 class ReduceConditionDurationUpgrade(Inherent, CastOutTheUnclean):
@@ -2352,38 +5612,349 @@ class PiercingArmorPlusVsDamageUpgrade(Inherent, ThroughThickAndThin):
 
 @dataclass(eq=False)
 class ArmorVsSpeciesUpgrade(Inherent):
-    armor: int = 0
+    armor: int = 10
     species: ItemBaneSpecies | None = None
-
     target_item_type = ItemType.Weapon
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsSpecies,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.ArmorPlusVsSpecies, ModifierType.Arg2, 5, 10)
-    
-    
 
+    #TODO: implement proper encoded description once we have the correct bytes for the species
+    def create_encoded_description(self) -> GWStringEncoded:
+        if self.species is None:
+            return GWStringEncoded(bytes(), f"Armor +{self.armor} ({_humanize_identifier(self.__class__.__name__)})")
+        
+        species = self.species.name if self.species != ItemBaneSpecies.Unknown else f"Unknown species ({self.species.value})"
+        return GWStringEncoded(bytes(), f"Armor +{self.armor} (vs. {species}) [{_humanize_identifier(self.__class__.__name__)}]")
+
+@dataclass(eq=False)
+class ArmorVsUndeadUpgrade(ArmorVsSpeciesUpgrade):
+    species = ItemBaneSpecies.Undead
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Undead,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class ArmorVsCharrUpgrade(ArmorVsSpeciesUpgrade):
+    species = ItemBaneSpecies.Charr
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Charr,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class ArmorVsTrollsUpgrade(ArmorVsSpeciesUpgrade):
+    species = ItemBaneSpecies.Trolls
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Trolls,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class ArmorVsPlantsUpgrade(ArmorVsSpeciesUpgrade):
+    species = ItemBaneSpecies.Plants
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Plants,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class ArmorVsSkeletonsUpgrade(ArmorVsSpeciesUpgrade):
+    species = ItemBaneSpecies.Skeletons
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Skeletons,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class ArmorVsGiantsUpgrade(ArmorVsSpeciesUpgrade):
+    species = ItemBaneSpecies.Giants
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Giants,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class ArmorVsDwarvesUpgrade(ArmorVsSpeciesUpgrade):
+    species = ItemBaneSpecies.Dwarves
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Dwarves,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class ArmorVsTengusUpgrade(ArmorVsSpeciesUpgrade):
+    species = ItemBaneSpecies.Tengus
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Tengus,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class ArmorVsDemonsUpgrade(ArmorVsSpeciesUpgrade):
+    species = ItemBaneSpecies.Demons
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Demons,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class ArmorVsDragonsUpgrade(ArmorVsSpeciesUpgrade):
+    species = ItemBaneSpecies.Dragons
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Dragons,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class ArmorVsOgresUpgrade(ArmorVsSpeciesUpgrade):
+    species = ItemBaneSpecies.Ogres
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="species",
+            fixed_value=ItemBaneSpecies.Ogres,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.species,
+            ),
+        ),
+        ranged(
+            identifier=ModifierIdentifier.ArmorPlusVsSpecies,
+            target="armor",
+            min_value=5,
+            max_value=10,
+            value_getter=property_value(
+                ArmorPlusVsSpecies,
+                lambda prop: prop.armor,
+            ),
+        ),
+    )
+        
 #endregion OffhandOrShield
 
 #region EquippableItem
 @dataclass(eq=False)
 class HealthPlusUpgrade(Inherent):
-    health: int = 0
-
+    health: int = 30
     target_item_type = ItemType.EquippableItem
-    property_identifiers = [
-        any_of(ModifierIdentifier.HealthPlus2, ModifierIdentifier.HealthPlus),
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HealthPlus2, ModifierType.Arg1, 10, 30)
+
+    upgrade_info = (
+        ranged(
+            identifier=any_of(ModifierIdentifier.HealthPlus, ModifierIdentifier.HealthPlus2),
+            target="health",
+            min_value=10,
+            max_value=30,
+            value_getter=property_value(
+                HealthPlus,
+                lambda prop: prop.health,
+            ),
+        ),
+     )
+
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.HEALTH_BYTES, self.health, "Health")
 
 @dataclass(eq=False)
 class EnergyUpgrade(Inherent):
-    energy: int = 0
-
     target_item_type = ItemType.EquippableItem
-    property_identifiers = [
-        any_of(ModifierIdentifier.Energy, ModifierIdentifier.Energy2),
-    ]
+    energy: int = 5
+    
+    upgrade_info = (
+        ranged(
+            identifier=any_of(ModifierIdentifier.Energy, ModifierIdentifier.Energy2),
+            target="energy",
+            min_value=0,
+            max_value=12,
+            value_getter=property_value(
+                EnergyProperty,
+                lambda prop: prop.energy,
+            ),
+        ),
+     )
+    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWEncoded._bonus_plus_num(GWEncoded.ITEM_BASIC, GWEncoded.ENERGY_BYTES, self.energy, "Energy")
+
     
 @dataclass(eq=False)
 class HighlySalvageableUpgrade(Inherent, MeasureForMeasure):
@@ -2398,29 +5969,1129 @@ class IncreasedSaleValueUpgrade(Inherent, ShowMeTheMoney):
 #region SpellcastingWeapon
 @dataclass(eq=False)
 class HalvesCastingTimeAttributeUpgrade(Inherent):
-    chance: int = 0
+    chance: int = 20
     attribute: Attribute | None = None
-
     target_item_type = ItemType.SpellcastingWeapon
-    property_identifiers = [
-        ModifierIdentifier.HalvesCastingTimeAttribute,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesCastingTimeAttribute, ModifierType.Arg1, 10, 20)
 
+    def create_encoded_description(self) -> GWStringEncoded:
+        if self.attribute is None:
+            return GWStringEncoded(bytes(), f"Halves casting time of spells of item's attribute (Chance: {self.chance}%)")
+        
+        attribute_bytes = GWEncoded._attribute_bytes(self.attribute)
+        if attribute_bytes:
+            base = GWEncoded._encoded(bytes([*self.get_text_color(), 0x81, 0xA, 0xA, 0x1, 0x47, 0xA, 0x1, 0x0, 0xB, 0x1, *attribute_bytes, 0x1, 0x0, 0x1, 0x0]), f"Halves casting time of {GWEncoded._attribute_name(self.attribute)} spells")
+            return GWEncoded._append_line_with_fallback(base, GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+        return GWStringEncoded(bytes(), f"Halves casting time of {GWEncoded._attribute_name(self.attribute)} spells (Chance: {self.chance}%)")
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfDivineFavorUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.DivineFavor
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.DivineFavor,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfHealingPrayersUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.HealingPrayers
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.HealingPrayers,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfSmitingPrayersUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.SmitingPrayers
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.SmitingPrayers,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfProtectionPrayersUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.ProtectionPrayers
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.ProtectionPrayers,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfSoulReapingUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.SoulReaping
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.SoulReaping,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfBloodMagicUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.BloodMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.BloodMagic,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfDeathMagicUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.DeathMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.DeathMagic,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfCursesUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.Curses
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.Curses,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfFastCastingUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.FastCasting
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.FastCasting,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfIllusionMagicUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.IllusionMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.IllusionMagic,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfDominationMagicUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.DominationMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.DominationMagic,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfInspirationMagicUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.InspirationMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.InspirationMagic,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfEnergyStorageUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.EnergyStorage
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.EnergyStorage,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfAirMagicUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.AirMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.AirMagic,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfEarthMagicUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.EarthMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.EarthMagic,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfFireMagicUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.FireMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.FireMagic,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfWaterMagicUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.WaterMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.WaterMagic,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfSpawningPowerUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.SpawningPower
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.SpawningPower,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfCommuningUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.Communing
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.Communing,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfRestorationMagicUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.RestorationMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.RestorationMagic,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesCastingTimeOfChannelingMagicUpgrade(HalvesCastingTimeAttributeUpgrade):
+    attribute = Attribute.ChannelingMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesCastingTimeAttribute,
+            target="attribute",
+            fixed_value=Attribute.ChannelingMagic,
+            value_getter=property_value(
+                HalvesCastingTimeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
     
     
 @dataclass(eq=False)
 class HalvesRechargeTimeAttributeUpgrade(Inherent):
-    chance: int = 0
+    chance: int = 20
     attribute: Attribute | None = None
-
     target_item_type = ItemType.SpellcastingWeapon
-    property_identifiers = [
-        ModifierIdentifier.HalvesSkillRechargeAttribute,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.HalvesSkillRechargeAttribute, ModifierType.Arg1, 10, 20)
 
-    
+    def create_encoded_description(self) -> GWStringEncoded:
+        if self.attribute is None:
+            return GWStringEncoded(bytes(), f"Halves skill recharge of spells of item's attribute (Chance: {self.chance}%)")
+        
+        attribute_bytes = GWEncoded._attribute_bytes(self.attribute)
+        if attribute_bytes:
+            base = GWEncoded._encoded(bytes([*self.get_text_color(), 0x81, 0xA, 0xA, 0x1, 0x58, 0xA, 0x1, 0x0, 0xB, 0x1, *attribute_bytes, 0x1, 0x0, 0x1, 0x0]), f"Halves skill recharge of {GWEncoded._attribute_name(self.attribute)} spells")
+            return GWEncoded._append_line_with_fallback(base, GWEncoded._dull_parenthesized(bytes([0x87, 0xA, 0xA, 0x1, 0x48, 0xA, 0x1, 0x0, 0x1, 0x1, self.chance, 0x1, 0x1, 0x0, 0x1, 0x0]), f"(Chance: {self.chance}%)"), f"(Chance: {self.chance}%)")
+        return GWEncoded._encoded(bytes(), f"Halves skill recharge of {GWEncoded._attribute_name(self.attribute)} spells (Chance: {self.chance}%)")
+
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfDivineFavorUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.DivineFavor
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.DivineFavor,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfHealingPrayersUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.HealingPrayers
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.HealingPrayers,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfSmitingPrayersUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.SmitingPrayers
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.SmitingPrayers,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfProtectionPrayersUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.ProtectionPrayers
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.ProtectionPrayers,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfSoulReapingUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.SoulReaping
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.SoulReaping,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfBloodMagicUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.BloodMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.BloodMagic,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfDeathMagicUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.DeathMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.DeathMagic,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfCursesUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.Curses
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.Curses,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfFastCastingUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.FastCasting
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.FastCasting,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfIllusionMagicUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.IllusionMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.IllusionMagic,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfDominationMagicUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.DominationMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.DominationMagic,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfInspirationMagicUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.InspirationMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.InspirationMagic,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfEnergyStorageUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.EnergyStorage
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.EnergyStorage,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfAirMagicUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.AirMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.AirMagic,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfEarthMagicUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.EarthMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.EarthMagic,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfFireMagicUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.FireMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.FireMagic,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfWaterMagicUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.WaterMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.WaterMagic,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfSpawningPowerUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.SpawningPower
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.SpawningPower,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfCommuningUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.Communing
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.Communing,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfRestorationMagicUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.RestorationMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.RestorationMagic,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
+
+@dataclass(eq=False)
+class HalvesRechargeTimeOfChannelingMagicUpgrade(HalvesRechargeTimeAttributeUpgrade):
+    attribute = Attribute.ChannelingMagic
+
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="chance",
+            min_value=10,
+            max_value=20,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.chance,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.HalvesSkillRechargeAttribute,
+            target="attribute",
+            fixed_value=Attribute.ChannelingMagic,
+            value_getter=property_value(
+                HalvesSkillRechargeAttribute,
+                lambda prop: prop.attribute,
+            ),
+        ),
+    )
     
     
 @dataclass(eq=False)
@@ -2450,85 +7121,109 @@ class EnergyPlusHexedUpgrade(Inherent, IAmSorrow):
 
 @dataclass(eq=False)
 class EnergyPlusEnergyRegenerationMinusUpgrade(Inherent):
-    energy: int = 0
-    energy_regen: int = 0
+    energy: int = 15
+    energy_regeneration: int = -1
 
-    property_identifiers = [
-        ModifierIdentifier.EnergyPlus,
-        ModifierIdentifier.EnergyRegeneration,
-    ]
-    modifier_range = ModifierRange(ModifierIdentifier.EnergyPlus, ModifierType.Arg2, 10, 15)
+    upgrade_info = (
+        ranged(
+            identifier=ModifierIdentifier.EnergyPlus,
+            target="energy",
+            min_value=10,
+            max_value=15,
+            value_getter=property_value(
+                EnergyPlus,
+                lambda prop: prop.energy,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.EnergyRegeneration,
+            target="energy_regeneration",
+            fixed_value=-1,
+            value_getter=property_value(
+                EnergyRegeneration,
+                lambda prop: prop.energy_regeneration,
+            ),
+        ),
+     )
 
+    def create_encoded_description(self) -> GWStringEncoded:
+        parts = [
+            GWEncoded._bonus_plus_num(self.get_text_color(), GWEncoded.ENERGY_BYTES, self.energy, "Energy"),
+            GWEncoded._bonus_minus_num(self.get_text_color(), GWEncoded.ENERGY_REGEN_BYTES, abs(self.energy_regeneration), "Energy regeneration")
+        ]
+        
+        return GWEncoded.combine_encoded_strings(parts, f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)")
+    
 
     
 #endregion SpellcastingWeapon
 
 #endregion Inherent
-
 #endregion Weapon Upgrades
 
 #region Armor Upgrades
 @dataclass(eq=False)
-class Insignia(Upgrade):
-    mod_type = ItemUpgradeType.Prefix
-
-    id: ClassVar[ItemUpgrade]
-    inventory_icon: ClassVar[str]
-    profession: ClassVar[Profession] = Profession._None
-    
+class ArmorUpgrade(Upgrade):
+    profession: Profession = Profession._None
     rarity = Rarity.Blue
-
-    def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(bytes(), _humanize_identifier(self.__class__.__name__))
+    pass
     
 @dataclass(eq=False)
-class Rune(Upgrade):
-    RUNE_PATTERNS = {
-        ServerLanguage.English: r"^.*?\bRune\b\s*",
-        ServerLanguage.German: r"^.*?Rune\b\s*",
-        ServerLanguage.French: r"^Rune(?:\s+de\s+\S+)?\s*",
-        ServerLanguage.Italian: r"^Runa(?:\s+del\s+\S+)?\s*",
-        ServerLanguage.Spanish: r"^Runa(?:\s+de\s+\S+)?\s*",
-        ServerLanguage.Korean: r"^.*?룬",
-        ServerLanguage.Japanese: r"^.*?ルーン",
-        ServerLanguage.TraditionalChinese: r"^.*?符文",
-        ServerLanguage.Polish: r"^Runa(?:\s+\S+)?\s*",
-        ServerLanguage.Russian: r"^.*?\bRune\b\s*",
-    }
+class Insignia(ArmorUpgrade):
+    mod_type = ItemUpgradeType.Prefix
+
+    @classmethod
+    def _can_compose(cls, mod: DecodedModifier, all_modifiers: list[DecodedModifier], remaining_modifiers: list[DecodedModifier]) -> bool:
+        return mod.identifier == ModifierIdentifier.Upgrade
     
+@dataclass(eq=False)
+class Rune(ArmorUpgrade):    
     mod_type = ItemUpgradeType.Suffix
 
-    id: ClassVar[ItemUpgrade]
-    inventory_icon: ClassVar[str]
-    profession: ClassVar[Profession] = Profession._None
-    
-    rarity = Rarity.Blue
-
-    def create_encoded_name(self) -> GWStringEncoded:
-        return GWStringEncoded(bytes(), _humanize_identifier(self.__class__.__name__))
+    @classmethod
+    def _can_compose(cls, mod: DecodedModifier, all_modifiers: list[DecodedModifier], remaining_modifiers: list[DecodedModifier]) -> bool:
+        return mod.identifier == ModifierIdentifier.Upgrade
 
 @dataclass(eq=False)
 class AttributeRune(Rune):
     attribute: Attribute = Attribute.None_
     attribute_level: int = 0
+    upgrade_rune_id : ItemUpgradeId = ItemUpgradeId.Unknown
+    applies_to_rune_id : ItemUpgradeId = ItemUpgradeId.Unknown
 
+    @classmethod
+    def _can_compose(cls, mod: DecodedModifier, all_modifiers: list[DecodedModifier], remaining_modifiers: list[DecodedModifier]) -> bool:
+        if mod.identifier != ModifierIdentifier.AttributeRune:
+            return False
+
+        modifier_index = all_modifiers.index(mod)
+        if modifier_index <= 0:
+            return False
+
+        for previous_mod in reversed(all_modifiers[:modifier_index]):
+            if previous_mod.identifier == ModifierIdentifier.TooltipDescription:
+                continue
+
+            return previous_mod.upgrade_id in (cls.applies_to_rune_id, cls.upgrade_rune_id)
+
+        return False
+    
     @classmethod
     def _pre_compose(cls, upgrade: "Upgrade", mod: DecodedModifier, all_modifiers: list[DecodedModifier], remaining_modifiers: list[DecodedModifier]) -> None:
         attribute_rune = cast("AttributeRune", upgrade)
         attribute_rune.attribute = Attribute(mod.arg1)
         attribute_rune.attribute_level = mod.arg2
-
+                
     def create_encoded_description(self) -> GWStringEncoded:
         attribute = GWEncoded.ATTRIBUTE_NAMES.get(self.attribute, bytes())
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{AttributeNames.get(self.attribute)}: {self.attribute_level}" if attribute else ""
 
-        match self.attribute_level:
-            case 3:
-                gold_value = 100
+        match self.rarity:
+            case Rarity.Gold:
                 encoded_description = bytes([ 
                                             *self.get_text_color(), *GWEncoded.PLUS_NUM_TEMPLATE, *attribute, 0x1, 0x0, 0x1, 0x1, self.attribute_level, 0x1, 0x1, 0x0, *GWEncoded.ITEM_DULL, *GWEncoded.NOT_STACKING_BYTES, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 
                                             *self.get_text_color(), *GWEncoded.HEALTH_MINUS_NUM, 75, 0x1, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1])
-            case 2:
+            case Rarity.Purple:
                 encoded_description = bytes([
                                             *self.get_text_color(), *GWEncoded.PLUS_NUM_TEMPLATE, *attribute, 0x1, 0x0, 0x1, 0x1, self.attribute_level, 0x1, 0x1, 0x0, *GWEncoded.ITEM_DULL, *GWEncoded.NOT_STACKING_BYTES, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 
                                             *self.get_text_color(), *GWEncoded.HEALTH_MINUS_NUM, 35, 0x1, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1])
@@ -2539,12 +7234,67 @@ class AttributeRune(Rune):
         return GWStringEncoded(encoded_description, fallback)
 
 @dataclass(eq=False)
+class MinorAttributeRune(AttributeRune):
+    attribute_level = 1
+    rarity = Rarity.Blue
+    
+@dataclass(eq=False)
+class MajorAttributeRune(AttributeRune):
+    attribute_level = 2
+    rarity = Rarity.Purple
+    
+    health_reduction: int = 35
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.HealthMinus,
+            target="health_reduction",
+            fixed_value=35,
+            value_getter=property_value(
+                HealthMinus,
+                lambda prop: prop.health_reduction,
+            ),
+        ),
+     )
+    
+@dataclass(eq=False)
+class SuperiorAttributeRune(AttributeRune):
+    attribute_level = 3
+    rarity = Rarity.Gold
+    
+    health_reduction: int = 75
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.HealthMinus,
+            target="health_reduction",
+            fixed_value=75,
+            value_getter=property_value(
+                HealthMinus,
+                lambda prop: prop.health_reduction,
+            ),
+        ),
+     )
+    
+@dataclass(eq=False)
 class AppliesToRune(Upgrade):
-    pass
+    id = ItemUpgrade.AppliesToRune
+    mod_type = ItemUpgradeType.AppliesToRune
+    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes(), f"Indicates the very next property specifies a {_humanize_identifier(self.modifier.upgrade_id.name) if self.modifier else 'rune'}.")
+    
+    def create_encoded_name(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes(), f"Applies To Rune ({_humanize_identifier(self.modifier.upgrade_id.name) if self.modifier else 'No upgrade present'})")
 
 @dataclass(eq=False)
 class UpgradeRune(Upgrade):
-    pass
+    id = ItemUpgrade.UpgradeRune
+    mod_type = ItemUpgradeType.UpgradeRune
+    
+    def create_encoded_description(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes(), f"Indicates the very next property specifies a {_humanize_identifier(self.modifier.upgrade_id.name) if self.modifier else 'rune'}.")
+    
+    def create_encoded_name(self) -> GWStringEncoded:
+        return GWStringEncoded(bytes(), f"{_humanize_identifier(self.modifier.upgrade_id.name) if self.modifier else 'Upgrade Rune'}")
 
 #region No Profession
 
@@ -2555,7 +7305,7 @@ class SurvivorInsignia(Insignia):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x3D, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xE3, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x52, 0xA, 0x1, 0x0, 0x1, 0x1, 0xF, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x67, 0x4C, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x52, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x68, 0x4C, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x52, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x69, 0x4C, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 @dataclass(eq=False)
@@ -2565,22 +7315,32 @@ class RadiantInsignia(Insignia):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x3D, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xE4, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x4F, 0xA, 0x1, 0x0, 0x1, 0x1, 0x3, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x67, 0x4C, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x4F, 0xA, 0x1, 0x0, 0x1, 0x1, 0x2, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x68, 0x4C, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x4F, 0xA, 0x1, 0x0, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x69, 0x4C, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 @dataclass(eq=False)
 class StalwartInsignia(Insignia):
     id = ItemUpgrade.StalwartInsignia
-    property_identifiers = [
-        ModifierIdentifier.ArmorPlusVsPhysical,
-    ]
+    armor : int = 10
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsPhysical,
+            target="armor",
+            fixed_value=10,
+            value_getter=property_value(
+                ArmorPlusVsPhysical,
+                lambda prop: prop.armor,
+            ),
+        ),
+     )
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x3D, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xE6, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB0, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 @dataclass(eq=False)
@@ -2590,7 +7350,7 @@ class BrawlersInsignia(Insignia):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x3D, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xE9, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB4, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 @dataclass(eq=False)
@@ -2600,7 +7360,7 @@ class BlessedInsignia(Insignia):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x3D, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xE7, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x9C, 0x4D, 0xA, 0x1, 0xB6, 0x4, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
     
 @dataclass(eq=False)
@@ -2610,7 +7370,7 @@ class HeraldsInsignia(Insignia):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x3D, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xE8, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB9, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
     
 @dataclass(eq=False)
@@ -2620,7 +7380,7 @@ class SentrysInsignia(Insignia):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x3D, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xE5, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xBA, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
     
 @dataclass(eq=False)
@@ -2632,7 +7392,7 @@ class RuneOfMinorVigor(Rune):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB5, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0xB0, 0x64, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB1, 0x64, 0x1, 0x1, 0x1E, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 @dataclass(eq=False)
@@ -2644,7 +7404,7 @@ class RuneOfMinorVigor2(Rune):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB5, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0xB0, 0x64, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB1, 0x64, 0x1, 0x1, 0x1E, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 @dataclass(eq=False)
@@ -2652,11 +7412,25 @@ class RuneOfVitae(Rune):
     id = ItemUpgrade.RuneOfVitae
     rarity = Rarity.Blue
 
+    health : int = 10
+    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.HealthPlus,
+            target="health",
+            fixed_value=10,
+            value_getter=property_value(
+                HealthPlus,
+                lambda prop: prop.health,
+            ),
+        ),
+    )
+    
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB5, 0x22, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xE, 0x59, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x52, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 @dataclass(eq=False)
@@ -2668,7 +7442,7 @@ class RuneOfAttunement(Rune):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB5, 0x22, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xD, 0x59, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x4F, 0xA, 0x1, 0x0, 0x1, 0x1, 0x2, 0x1, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 @dataclass(eq=False)
@@ -2680,39 +7454,79 @@ class RuneOfMajorVigor(Rune):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB5, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0xB0, 0x64, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([*self.get_text_color(), 0x8, 0x1, 0xA, 0x1, 0xB1, 0x64, 0x1, 0x1, 0x29, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
     
 @dataclass(eq=False)
 class RuneOfRecovery(Rune):
     id = ItemUpgrade.RuneOfRecovery
     rarity = Rarity.Purple
+    
+    condition_1: Reduced_Ailment = Reduced_Ailment.Dazed
+    condition_2: Reduced_Ailment = Reduced_Ailment.Deep_Wound
 
-    property_identifiers = [
-        ModifierIdentifier.ReduceConditionTupleDuration,
-    ]
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionTupleDuration,
+            target="condition_1",
+            fixed_value=Reduced_Ailment.Dazed,
+            value_getter=property_value(
+                ReduceConditionTupleDuration,
+                lambda prop: prop.condition_1,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionTupleDuration,
+            target="condition_2",
+            fixed_value=Reduced_Ailment.Deep_Wound,
+            value_getter=property_value(
+                ReduceConditionTupleDuration,
+                lambda prop: prop.condition_2,
+            ),
+        ),
+     )
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB5, 0x22, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xF, 0x59, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([*self.get_text_color(), 0xA7, 0xA, 0xA, 0x1, 0x96, 0x62, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, *self.get_text_color(), 0xA7, 0xA, 0xA, 0x1, 0x90, 0x62, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 @dataclass(eq=False)
 class RuneOfRestoration(Rune):
     id = ItemUpgrade.RuneOfRestoration
     rarity = Rarity.Purple
+    
+    condition_1: Reduced_Ailment = Reduced_Ailment.Bleeding
+    condition_2: Reduced_Ailment = Reduced_Ailment.Crippled
 
-    property_identifiers = [
-        ModifierIdentifier.ReduceConditionTupleDuration,
-    ]
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionTupleDuration,
+            target="condition_1",
+            fixed_value=Reduced_Ailment.Bleeding,
+            value_getter=property_value(
+                ReduceConditionTupleDuration,
+                lambda prop: prop.condition_1,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionTupleDuration,
+            target="condition_2",
+            fixed_value=Reduced_Ailment.Crippled,
+            value_getter=property_value(
+                ReduceConditionTupleDuration,
+                lambda prop: prop.condition_2,
+            ),
+        ),
+     )
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB5, 0x22, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0x10, 0x59, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([*self.get_text_color(), 0xA7, 0xA, 0xA, 0x1, 0x88, 0x62, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, *self.get_text_color(), 0xA7, 0xA, 0xA, 0x1, 0x8E, 0x62, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 @dataclass(eq=False)
@@ -2720,15 +7534,35 @@ class RuneOfClarity(Rune):
     id = ItemUpgrade.RuneOfClarity
     rarity = Rarity.Purple
 
-    property_identifiers = [
-        ModifierIdentifier.ReduceConditionTupleDuration,
-    ]
+    condition_1: Reduced_Ailment = Reduced_Ailment.Blind
+    condition_2: Reduced_Ailment = Reduced_Ailment.Weakness
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionTupleDuration,
+            target="condition_1",
+            fixed_value=Reduced_Ailment.Blind,
+            value_getter=property_value(
+                ReduceConditionTupleDuration,
+                lambda prop: prop.condition_1,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionTupleDuration,
+            target="condition_2",
+            fixed_value=Reduced_Ailment.Weakness,
+            value_getter=property_value(
+                ReduceConditionTupleDuration,
+                lambda prop: prop.condition_2,
+            ),
+        ),
+     )
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB5, 0x22, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0x11, 0x59, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([*self.get_text_color(), 0xA7, 0xA, 0xA, 0x1, 0x8A, 0x62, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, *self.get_text_color(), 0xA7, 0xA, 0xA, 0x1, 0x98, 0x62, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 @dataclass(eq=False)
@@ -2736,15 +7570,35 @@ class RuneOfPurity(Rune):
     id = ItemUpgrade.RuneOfPurity
     rarity = Rarity.Purple
 
-    property_identifiers = [
-        ModifierIdentifier.ReduceConditionTupleDuration,
-    ]
+    condition_1: Reduced_Ailment = Reduced_Ailment.Disease
+    condition_2: Reduced_Ailment = Reduced_Ailment.Poison
+
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionTupleDuration,
+            target="condition_1",
+            fixed_value=Reduced_Ailment.Disease,
+            value_getter=property_value(
+                ReduceConditionTupleDuration,
+                lambda prop: prop.condition_1,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ReduceConditionTupleDuration,
+            target="condition_2",
+            fixed_value=Reduced_Ailment.Poison,
+            value_getter=property_value(
+                ReduceConditionTupleDuration,
+                lambda prop: prop.condition_2,
+            ),
+        ),
+     )
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB5, 0x22, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0x12, 0x59, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([*self.get_text_color(), 0xA7, 0xA, 0xA, 0x1, 0x92, 0x62, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, *self.get_text_color(), 0xA7, 0xA, 0xA, 0x1, 0x94, 0x62, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 @dataclass(eq=False)
@@ -2756,7 +7610,7 @@ class RuneOfSuperiorVigor(Rune):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB5, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0xB0, 0x64, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([*self.get_text_color(), 0x8, 0x1, 0xA, 0x1, 0xB1, 0x64, 0x1, 0x1, 0x32, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 
@@ -2773,12 +7627,8 @@ class KnightsInsignia(Insignia):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x41, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0x4, 0x59, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x7E, 0xA, 0xA, 0x1, 0x1, 0x81, 0x4F, 0x5D, 0x1, 0x0, 0x1, 0x1, 0x3, 0x1, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: "Received physical damage -3"
-    }
 
 @dataclass(eq=False)
 class LieutenantsInsignia(Insignia):
@@ -2789,12 +7639,8 @@ class LieutenantsInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0x97, 0x64, 0x1, 0x1, 0x14, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x7E, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x14, 0x1, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Reduces Hex durations on you by 20% and damage dealt by you by 5% (Non-stacking)\nArmor -20"
-    }
 
 @dataclass(eq=False)
 class StonefistInsignia(Insignia):
@@ -2805,12 +7651,8 @@ class StonefistInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0x99, 0x64, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Increases knockdown time on foes by 1 second.\n(Maximum: 3 seconds)"
-    }
 
 @dataclass(eq=False)
 class DreadnoughtInsignia(Insignia):
@@ -2821,12 +7663,8 @@ class DreadnoughtInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAD, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (vs. elemental damage)"
-    }
 
 @dataclass(eq=False)
 class SentinelsInsignia(Insignia):
@@ -2837,70 +7675,94 @@ class SentinelsInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x14, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xA9, 0xA, 0xA, 0x1, 0x40, 0x9, 0x1, 0x0, 0x1, 0x1, 0xD, 0x1, 0x2, 0x0, 0xAB, 0xA, 0x2, 0x0, 0xAD, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
+    
+@dataclass(eq=False)
+class MinorWarriorRune(MinorAttributeRune):
+    profession = Profession.Warrior
+    upgrade_rune_id = ItemUpgradeId.MinorWarriorRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMinorWarriorRune
 
-    descriptions = {
-        ServerLanguage.English: f"Armor +20 (Requires 13 Strength, vs. elemental damage)"
-    }
+@dataclass(eq=False)
+class MajorWarriorRune(MajorAttributeRune):
+    profession = Profession.Warrior
+    upgrade_rune_id = ItemUpgradeId.MajorWarriorRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMajorWarriorRune
+
+@dataclass(eq=False)
+class SuperiorWarriorRune(SuperiorAttributeRune):
+    profession = Profession.Warrior
+    upgrade_rune_id = ItemUpgradeId.SuperiorWarriorRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToSuperiorWarriorRune
 
 @dataclass(eq=False)
 class WarriorRuneOfMinorAbsorption(Rune):
     id = ItemUpgrade.WarriorRuneOfMinorAbsorption
+    upgrade_rune_id = ItemUpgradeId.MinorWarriorRune
     profession = Profession.Warrior
-    rarity = Rarity.Blue
+    rarity = Rarity.Blue    
+    
+    # upgrade_info = (
+    #     fixed(
+    #         identifier=ModifierIdentifier.,
+    #         target="armor_vs_elemental",
+    #         fixed_value=10,
+    #         value_getter=property_value(
+    #             ArmorPlusVsElemental,
+    #             lambda prop: prop.armor,
+    #         ),
+    #     ),
+    # )
+    
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0xFA, 0x64, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
-    encoded_description = bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xFB, 0x64, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1])
-    
+    def create_encoded_description(self) -> GWStringEncoded:
+        encoded_description = bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xFB, 0x64, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1])
+        return GWStringEncoded(self.get_text_color() + encoded_description, f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)")
 
 @dataclass(eq=False)
-class WarriorRuneOfMinorTactics(AttributeRune):
+class WarriorRuneOfMinorTactics(MinorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfMinorTactics
-    profession = Profession.Warrior
-    rarity = Rarity.Blue
+    attribute = Attribute.Tactics
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x48, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class WarriorRuneOfMinorStrength(AttributeRune):
+class WarriorRuneOfMinorStrength(MinorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfMinorStrength
-    profession = Profession.Warrior
-    rarity = Rarity.Blue
+    attribute = Attribute.Strength
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x40, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class WarriorRuneOfMinorAxeMastery(AttributeRune):
+class WarriorRuneOfMinorAxeMastery(MinorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfMinorAxeMastery
-    profession = Profession.Warrior
-    rarity = Rarity.Blue
+    attribute = Attribute.AxeMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x42, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class WarriorRuneOfMinorHammerMastery(AttributeRune):
+class WarriorRuneOfMinorHammerMastery(MinorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfMinorHammerMastery
-    profession = Profession.Warrior
-    rarity = Rarity.Blue
+    attribute = Attribute.HammerMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x44, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class WarriorRuneOfMinorSwordsmanship(AttributeRune):
+class WarriorRuneOfMinorSwordsmanship(MinorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfMinorSwordsmanship
-    profession = Profession.Warrior
-    rarity = Rarity.Blue
+    attribute = Attribute.Swordsmanship
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x46, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
@@ -2916,75 +7778,50 @@ class WarriorRuneOfMajorAbsorption(Rune):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0xFA, 0x64, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([*self.get_text_color(), 0x8, 0x1, 0xA, 0x1, 0xFB, 0x64, 0x1, 0x1, 0x2, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
     
 @dataclass(eq=False)
-class WarriorRuneOfMajorTactics(AttributeRune):
+class WarriorRuneOfMajorTactics(MajorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfMajorTactics
-    profession = Profession.Warrior
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Tactics
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x48, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class WarriorRuneOfMajorStrength(AttributeRune):
+class WarriorRuneOfMajorStrength(MajorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfMajorStrength
-    profession = Profession.Warrior
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Strength
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x40, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class WarriorRuneOfMajorAxeMastery(AttributeRune):
+class WarriorRuneOfMajorAxeMastery(MajorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfMajorAxeMastery
-    profession = Profession.Warrior
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.AxeMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x42, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class WarriorRuneOfMajorHammerMastery(AttributeRune):
+class WarriorRuneOfMajorHammerMastery(MajorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfMajorHammerMastery
-    profession = Profession.Warrior
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.HammerMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x44, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class WarriorRuneOfMajorSwordsmanship(AttributeRune):
+class WarriorRuneOfMajorSwordsmanship(MajorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfMajorSwordsmanship
-    profession = Profession.Warrior
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Swordsmanship
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x46, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
@@ -2993,6 +7830,7 @@ class WarriorRuneOfMajorSwordsmanship(AttributeRune):
 @dataclass(eq=False)
 class WarriorRuneOfSuperiorAbsorption(Rune):
     id = ItemUpgrade.WarriorRuneOfSuperiorAbsorption
+    upgrade_rune_id = ItemUpgradeId.SuperiorWarriorRune
     profession = Profession.Warrior
     rarity = Rarity.Gold
 
@@ -3000,115 +7838,54 @@ class WarriorRuneOfSuperiorAbsorption(Rune):
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0xFA, 0x64, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([*self.get_text_color(), 0x8, 0x1, 0xA, 0x1, 0xFB, 0x64, 0x1, 0x1, 0x3, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
 
 @dataclass(eq=False)
-class WarriorRuneOfSuperiorTactics(AttributeRune):
+class WarriorRuneOfSuperiorTactics(SuperiorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfSuperiorTactics
-    profession = Profession.Warrior
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Tactics
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x48, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class WarriorRuneOfSuperiorStrength(AttributeRune):
+class WarriorRuneOfSuperiorStrength(SuperiorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfSuperiorStrength
-    profession = Profession.Warrior
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Strength
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x40, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class WarriorRuneOfSuperiorAxeMastery(AttributeRune):
+class WarriorRuneOfSuperiorAxeMastery(SuperiorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfSuperiorAxeMastery
-    profession = Profession.Warrior
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.AxeMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x42, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class WarriorRuneOfSuperiorHammerMastery(AttributeRune):
+class WarriorRuneOfSuperiorHammerMastery(SuperiorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfSuperiorHammerMastery
-    profession = Profession.Warrior
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.HammerMastery
+    attribute = Attribute.HammerMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x44, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class WarriorRuneOfSuperiorSwordsmanship(AttributeRune):
+class WarriorRuneOfSuperiorSwordsmanship(SuperiorWarriorRune):
     id = ItemUpgrade.WarriorRuneOfSuperiorSwordsmanship
-    profession = Profession.Warrior
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Swordsmanship
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBA, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x46, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
-
-@dataclass(eq=False)
-class UpgradeMinorRuneWarrior(UpgradeRune):
-    id = ItemUpgrade.UpgradeMinorRuneWarrior
-    profession = Profession.Warrior
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeMajorRuneWarrior(UpgradeRune):
-    id = ItemUpgrade.UpgradeMajorRuneWarrior
-    profession = Profession.Warrior
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeSuperiorRuneWarrior(UpgradeRune):
-    id = ItemUpgrade.UpgradeSuperiorRuneWarrior
-    profession = Profession.Warrior
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class AppliesToMinorRuneWarrior(AppliesToRune):
-    id = ItemUpgrade.AppliesToMinorRuneWarrior
-    profession = Profession.Warrior
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToMajorRuneWarrior(AppliesToRune):
-    id = ItemUpgrade.AppliesToMajorRuneWarrior
-    profession = Profession.Warrior
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToSuperiorRuneWarrior(AppliesToRune):
-    id = ItemUpgrade.AppliesToSuperiorRuneWarrior
-    profession = Profession.Warrior
-    mod_type = ItemUpgradeType.AppliesToRune
 
 #endregion Warrior
 
@@ -3123,12 +7900,8 @@ class FrostboundInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xF, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAC, 0xA, 0xA, 0x1, 0xE1, 0x8, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +15 (vs. Cold damage)"
-    }
 
 @dataclass(eq=False)
 class PyreboundInsignia(Insignia):
@@ -3139,12 +7912,8 @@ class PyreboundInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xF, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAC, 0xA, 0xA, 0x1, 0xE4, 0x8, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +15 (vs. Fire damage)"
-    }
 
 @dataclass(eq=False)
 class StormboundInsignia(Insignia):
@@ -3155,12 +7924,8 @@ class StormboundInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xF, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAC, 0xA, 0xA, 0x1, 0xE3, 0x8, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +15 (vs. Lightning damage)"
-    }
 
 @dataclass(eq=False)
 class ScoutsInsignia(Insignia):
@@ -3171,12 +7936,8 @@ class ScoutsInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xBF, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (while using a Preparation)"
-    }
 
 @dataclass(eq=False)
 class EarthboundInsignia(Insignia):
@@ -3187,12 +7948,8 @@ class EarthboundInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xF, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAC, 0xA, 0xA, 0x1, 0xE2, 0x8, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +15 (vs. Earth damage)"
-    }
 
 @dataclass(eq=False)
 class BeastmastersInsignia(Insignia):
@@ -3203,200 +7960,133 @@ class BeastmastersInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x5E, 0x4D, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (while your pet is alive)"
-    }
+@dataclass(eq=False)
+class MinorRangerRune(MinorAttributeRune):
+    profession = Profession.Ranger
+    upgrade_rune_id = ItemUpgradeId.MinorRangerRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMinorRangerRune
 
 @dataclass(eq=False)
-class RangerRuneOfMinorWildernessSurvival(AttributeRune):
-    id = ItemUpgrade.RangerRuneOfMinorWildernessSurvival
+class MajorRangerRune(MajorAttributeRune):
     profession = Profession.Ranger
-    rarity = Rarity.Blue
+    upgrade_rune_id = ItemUpgradeId.MajorRangerRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMajorRangerRune
+
+@dataclass(eq=False)
+class SuperiorRangerRune(SuperiorAttributeRune):
+    profession = Profession.Ranger
+    upgrade_rune_id = ItemUpgradeId.SuperiorRangerRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToSuperiorRangerRune
+
+@dataclass(eq=False)
+class RangerRuneOfMinorWildernessSurvival(MinorRangerRune):
+    id = ItemUpgrade.RangerRuneOfMinorWildernessSurvival
+    attribute = Attribute.WildernessSurvival
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBB, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x54, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RangerRuneOfMinorExpertise(AttributeRune):
+class RangerRuneOfMinorExpertise(MinorRangerRune):
     id = ItemUpgrade.RangerRuneOfMinorExpertise
-    profession = Profession.Ranger
-    rarity = Rarity.Blue
+    attribute = Attribute.Expertise
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBB, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x52, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RangerRuneOfMinorBeastMastery(AttributeRune):
+class RangerRuneOfMinorBeastMastery(MinorRangerRune):
     id = ItemUpgrade.RangerRuneOfMinorBeastMastery
-    profession = Profession.Ranger
-    rarity = Rarity.Blue
+    attribute = Attribute.BeastMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBB, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x50, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RangerRuneOfMinorMarksmanship(AttributeRune):
+class RangerRuneOfMinorMarksmanship(MinorRangerRune):
     id = ItemUpgrade.RangerRuneOfMinorMarksmanship
-    profession = Profession.Ranger
-    rarity = Rarity.Blue
+    attribute = Attribute.Marksmanship
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBB, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x56, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RangerRuneOfMajorWildernessSurvival(AttributeRune):
+class RangerRuneOfMajorWildernessSurvival(MajorRangerRune):
     id = ItemUpgrade.RangerRuneOfMajorWildernessSurvival
-    profession = Profession.Ranger
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.WildernessSurvival
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBB, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x54, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RangerRuneOfMajorExpertise(AttributeRune):
+class RangerRuneOfMajorExpertise(MajorRangerRune):
     id = ItemUpgrade.RangerRuneOfMajorExpertise
-    profession = Profession.Ranger
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Expertise
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBB, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x52, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RangerRuneOfMajorBeastMastery(AttributeRune):
+class RangerRuneOfMajorBeastMastery(MajorRangerRune):
     id = ItemUpgrade.RangerRuneOfMajorBeastMastery
-    profession = Profession.Ranger
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.BeastMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBB, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x50, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RangerRuneOfMajorMarksmanship(AttributeRune):
+class RangerRuneOfMajorMarksmanship(MajorRangerRune):
     id = ItemUpgrade.RangerRuneOfMajorMarksmanship
-    profession = Profession.Ranger
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Marksmanship
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBB, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x56, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RangerRuneOfSuperiorWildernessSurvival(AttributeRune):
+class RangerRuneOfSuperiorWildernessSurvival(SuperiorRangerRune):
     id = ItemUpgrade.RangerRuneOfSuperiorWildernessSurvival
-    profession = Profession.Ranger
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.WildernessSurvival
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBB, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x54, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RangerRuneOfSuperiorExpertise(AttributeRune):
+class RangerRuneOfSuperiorExpertise(SuperiorRangerRune):
     id = ItemUpgrade.RangerRuneOfSuperiorExpertise
-    profession = Profession.Ranger
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Expertise
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBB, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x52, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RangerRuneOfSuperiorBeastMastery(AttributeRune):
+class RangerRuneOfSuperiorBeastMastery(SuperiorRangerRune):
     id = ItemUpgrade.RangerRuneOfSuperiorBeastMastery
-    profession = Profession.Ranger
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.BeastMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBB, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x50, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RangerRuneOfSuperiorMarksmanship(AttributeRune):
+class RangerRuneOfSuperiorMarksmanship(SuperiorRangerRune):
     id = ItemUpgrade.RangerRuneOfSuperiorMarksmanship
-    profession = Profession.Ranger
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Marksmanship
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBB, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x56, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
-
-@dataclass(eq=False)
-class UpgradeMinorRuneRanger(UpgradeRune):
-    id = ItemUpgrade.UpgradeMinorRuneRanger
-    profession = Profession.Ranger
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeMajorRuneRanger(UpgradeRune):
-    id = ItemUpgrade.UpgradeMajorRuneRanger
-    profession = Profession.Ranger
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeSuperiorRuneRanger(UpgradeRune):
-    id = ItemUpgrade.UpgradeSuperiorRuneRanger
-    profession = Profession.Ranger
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class AppliesToMinorRuneRanger(AppliesToRune):
-    id = ItemUpgrade.AppliesToMinorRuneRanger
-    profession = Profession.Ranger
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToMajorRuneRanger(AppliesToRune):
-    id = ItemUpgrade.AppliesToMajorRuneRanger
-    profession = Profession.Ranger
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToSuperiorRuneRanger(AppliesToRune):
-    id = ItemUpgrade.AppliesToSuperiorRuneRanger
-    profession = Profession.Ranger
-    mod_type = ItemUpgradeType.AppliesToRune
 
 #endregion Ranger
 
@@ -3411,12 +8101,8 @@ class WanderersInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAD, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (vs. elemental damage)"
-    }
 
 @dataclass(eq=False)
 class DisciplesInsignia(Insignia):
@@ -3427,12 +8113,8 @@ class DisciplesInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xF, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x9C, 0x4D, 0xA, 0x1, 0xAC, 0x4, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +15 (while affected by a Condition)"
-    }
 
 @dataclass(eq=False)
 class AnchoritesInsignia(Insignia):
@@ -3443,201 +8125,134 @@ class AnchoritesInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x5F, 0x4D, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x5F, 0x4D, 0x1, 0x1, 0x3, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x5F, 0x4D, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
-    descriptions = {
-        ServerLanguage.English: f"Armor +5 (while recharging 1 or more skills)\nArmor +5 (while recharging 3 or more skills)\nArmor +5 (while recharging 5 or more skills)"
-
-    }
+@dataclass(eq=False)
+class MinorMonkRune(MinorAttributeRune):
+    profession = Profession.Monk
+    upgrade_rune_id = ItemUpgradeId.MinorMonkRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMinorMonkRune
 
 @dataclass(eq=False)
-class MonkRuneOfMinorHealingPrayers(AttributeRune):
-    id = ItemUpgrade.MonkRuneOfMinorHealingPrayers
+class MajorMonkRune(MajorAttributeRune):
     profession = Profession.Monk
-    rarity = Rarity.Blue
+    upgrade_rune_id = ItemUpgradeId.MajorMonkRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMajorMonkRune
+
+@dataclass(eq=False)
+class SuperiorMonkRune(SuperiorAttributeRune):
+    profession = Profession.Monk
+    upgrade_rune_id = ItemUpgradeId.SuperiorMonkRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToSuperiorMonkRune
+
+
+@dataclass(eq=False)
+class MonkRuneOfMinorHealingPrayers(MinorMonkRune):
+    id = ItemUpgrade.MonkRuneOfMinorHealingPrayers
+    attribute = Attribute.HealingPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB9, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x3A, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MonkRuneOfMinorSmitingPrayers(AttributeRune):
+class MonkRuneOfMinorSmitingPrayers(MinorMonkRune):
     id = ItemUpgrade.MonkRuneOfMinorSmitingPrayers
-    profession = Profession.Monk
-    rarity = Rarity.Blue
+    attribute = Attribute.SmitingPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB9, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x3E, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MonkRuneOfMinorProtectionPrayers(AttributeRune):
+class MonkRuneOfMinorProtectionPrayers(MinorMonkRune):
     id = ItemUpgrade.MonkRuneOfMinorProtectionPrayers
-    profession = Profession.Monk
-    rarity = Rarity.Blue
+    attribute = Attribute.ProtectionPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB9, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x3C, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MonkRuneOfMinorDivineFavor(AttributeRune):
+class MonkRuneOfMinorDivineFavor(MinorMonkRune):
     id = ItemUpgrade.MonkRuneOfMinorDivineFavor
-    profession = Profession.Monk
-    rarity = Rarity.Blue
+    attribute = Attribute.DivineFavor
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB9, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x38, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MonkRuneOfMajorHealingPrayers(AttributeRune):
+class MonkRuneOfMajorHealingPrayers(MajorMonkRune):
     id = ItemUpgrade.MonkRuneOfMajorHealingPrayers
-    profession = Profession.Monk
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.HealingPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB9, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x3A, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MonkRuneOfMajorSmitingPrayers(AttributeRune):
+class MonkRuneOfMajorSmitingPrayers(MajorMonkRune):
     id = ItemUpgrade.MonkRuneOfMajorSmitingPrayers
-    profession = Profession.Monk
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.SmitingPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB9, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x3E, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MonkRuneOfMajorProtectionPrayers(AttributeRune):
+class MonkRuneOfMajorProtectionPrayers(MajorMonkRune):
     id = ItemUpgrade.MonkRuneOfMajorProtectionPrayers
-    profession = Profession.Monk
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.ProtectionPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB9, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x3C, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MonkRuneOfMajorDivineFavor(AttributeRune):
+class MonkRuneOfMajorDivineFavor(MajorMonkRune):
     id = ItemUpgrade.MonkRuneOfMajorDivineFavor
-    profession = Profession.Monk
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.DivineFavor
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB9, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x38, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MonkRuneOfSuperiorHealingPrayers(AttributeRune):
+class MonkRuneOfSuperiorHealingPrayers(SuperiorMonkRune):
     id = ItemUpgrade.MonkRuneOfSuperiorHealingPrayers
-    profession = Profession.Monk
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.HealingPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB9, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x3A, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MonkRuneOfSuperiorSmitingPrayers(AttributeRune):
+class MonkRuneOfSuperiorSmitingPrayers(SuperiorMonkRune):
     id = ItemUpgrade.MonkRuneOfSuperiorSmitingPrayers
-    profession = Profession.Monk
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.SmitingPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB9, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x3E, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MonkRuneOfSuperiorProtectionPrayers(AttributeRune):
+class MonkRuneOfSuperiorProtectionPrayers(SuperiorMonkRune):
     id = ItemUpgrade.MonkRuneOfSuperiorProtectionPrayers
-    profession = Profession.Monk
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.ProtectionPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB9, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x3C, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MonkRuneOfSuperiorDivineFavor(AttributeRune):
+class MonkRuneOfSuperiorDivineFavor(SuperiorMonkRune):
     id = ItemUpgrade.MonkRuneOfSuperiorDivineFavor
-    profession = Profession.Monk
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.DivineFavor
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB9, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x38, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
-
-@dataclass(eq=False)
-class UpgradeMinorRuneMonk(UpgradeRune):
-    id = ItemUpgrade.UpgradeMinorRuneMonk
-    profession = Profession.Monk
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeMajorRuneMonk(UpgradeRune):
-    id = ItemUpgrade.UpgradeMajorRuneMonk
-    profession = Profession.Monk
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeSuperiorRuneMonk(UpgradeRune):
-    id = ItemUpgrade.UpgradeSuperiorRuneMonk
-    profession = Profession.Monk
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class AppliesToMinorRuneMonk(AppliesToRune):
-    id = ItemUpgrade.AppliesToMinorRuneMonk
-    profession = Profession.Monk
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToMajorRuneMonk(AppliesToRune):
-    id = ItemUpgrade.AppliesToMajorRuneMonk
-    profession = Profession.Monk
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToSuperiorRuneMonk(AppliesToRune):
-    id = ItemUpgrade.AppliesToSuperiorRuneMonk
-    profession = Profession.Monk
-    mod_type = ItemUpgradeType.AppliesToRune
 
 #endregion Monk
 
@@ -3652,12 +8267,8 @@ class BloodstainedInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0x7F, 0x64, 0x1, 0x1, 0x0, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x8, 0x1, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Reduces casting time of spells that exploit corpses by 25% (Non-stacking)"
-    }
 
 @dataclass(eq=False)
 class TormentorsInsignia(Insignia):
@@ -3668,13 +8279,9 @@ class TormentorsInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x1, 0x81, 0xE1, 0x53, 0xA, 0x1, 0xE7, 0x8, 0x1, 0x0, 0x1, 0x1, 0x6, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x67, 0x4C, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x1, 0x81, 0xE1, 0x53, 0xA, 0x1, 0xE7, 0x8, 0x1, 0x0, 0x1, 0x1, 0x4, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x68, 0x4C, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x1, 0x81, 0xE1, 0x53, 0xA, 0x1, 0xE7, 0x8, 0x1, 0x0, 0x1, 0x1, 0x2, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x69, 0x4C, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
-    descriptions = {
-        ServerLanguage.English: f"Holy damage you receive increased by 6 (on chest armor)\nHoly damage you receive increased by 4 (on leg armor)\nHoly damage you receive increased by 2 (on other armor)\nArmor +10"
-
-    }
 
 @dataclass(eq=False)
 class BonelaceInsignia(Insignia):
@@ -3685,12 +8292,8 @@ class BonelaceInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xF, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAC, 0xA, 0xA, 0x1, 0xDF, 0x8, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +15 (vs. Piercing damage)"
-    }
 
 @dataclass(eq=False)
 class MinionMastersInsignia(Insignia):
@@ -3701,13 +8304,9 @@ class MinionMastersInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x4E, 0x6D, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x4E, 0x6D, 0x1, 0x1, 0x3, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x4E, 0x6D, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
-    descriptions = {
-        ServerLanguage.English: f"Armor +5 (while you control 1 or more minions)\nArmor +5 (while you control 3 or more minions)\nArmor +5 (while you control 5 or more minions)"
-
-    }
 
 @dataclass(eq=False)
 class BlightersInsignia(Insignia):
@@ -3718,12 +8317,8 @@ class BlightersInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x14, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x9C, 0x4D, 0xA, 0x1, 0xB4, 0x4, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +20 (while affected by a Hex Spell)"
-    }
 
 @dataclass(eq=False)
 class UndertakersInsignia(Insignia):
@@ -3734,201 +8329,133 @@ class UndertakersInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xBB, 0xA, 0xA, 0x1, 0x52, 0xA, 0x1, 0x0, 0x1, 0x1, 0x50, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xBB, 0xA, 0xA, 0x1, 0x52, 0xA, 0x1, 0x0, 0x1, 0x1, 0x3C, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xBB, 0xA, 0xA, 0x1, 0x52, 0xA, 0x1, 0x0, 0x1, 0x1, 0x28, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xBB, 0xA, 0xA, 0x1, 0x52, 0xA, 0x1, 0x0, 0x1, 0x1, 0x14, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
-    descriptions = {
-        ServerLanguage.English: f"Armor +5 (while health is below 80%)\nArmor +5 (while health is below 60%)\nArmor +5 (while health is below 40%)\nArmor +5 (while health is below 20%)"
-
-    }
+@dataclass(eq=False)
+class MinorNecromancerRune(MinorAttributeRune):
+    profession = Profession.Necromancer
+    upgrade_rune_id = ItemUpgradeId.MinorNecromancerRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMinorNecromancerRune
 
 @dataclass(eq=False)
-class NecromancerRuneOfMinorBloodMagic(AttributeRune):
-    id = ItemUpgrade.NecromancerRuneOfMinorBloodMagic
+class MajorNecromancerRune(MajorAttributeRune):
     profession = Profession.Necromancer
-    rarity = Rarity.Blue
+    upgrade_rune_id = ItemUpgradeId.MajorNecromancerRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMajorNecromancerRune
+
+@dataclass(eq=False)
+class SuperiorNecromancerRune(SuperiorAttributeRune):
+    profession = Profession.Necromancer
+    upgrade_rune_id = ItemUpgradeId.SuperiorNecromancerRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToSuperiorNecromancerRune
+    
+@dataclass(eq=False)
+class NecromancerRuneOfMinorBloodMagic(MinorNecromancerRune):
+    id = ItemUpgrade.NecromancerRuneOfMinorBloodMagic
+    attribute = Attribute.BloodMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB7, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x26, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class NecromancerRuneOfMinorDeathMagic(AttributeRune):
+class NecromancerRuneOfMinorDeathMagic(MinorNecromancerRune):
     id = ItemUpgrade.NecromancerRuneOfMinorDeathMagic
-    profession = Profession.Necromancer
-    rarity = Rarity.Blue
+    attribute = Attribute.DeathMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB7, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x2A, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class NecromancerRuneOfMinorCurses(AttributeRune):
+class NecromancerRuneOfMinorCurses(MinorNecromancerRune):
     id = ItemUpgrade.NecromancerRuneOfMinorCurses
-    profession = Profession.Necromancer
-    rarity = Rarity.Blue
+    attribute = Attribute.Curses
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB7, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x28, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class NecromancerRuneOfMinorSoulReaping(AttributeRune):
+class NecromancerRuneOfMinorSoulReaping(MinorNecromancerRune):
     id = ItemUpgrade.NecromancerRuneOfMinorSoulReaping
-    profession = Profession.Necromancer
-    rarity = Rarity.Blue
+    attribute = Attribute.SoulReaping
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB7, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x2C, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class NecromancerRuneOfMajorBloodMagic(AttributeRune):
+class NecromancerRuneOfMajorBloodMagic(MajorNecromancerRune):
     id = ItemUpgrade.NecromancerRuneOfMajorBloodMagic
-    profession = Profession.Necromancer
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.BloodMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB7, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x26, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class NecromancerRuneOfMajorDeathMagic(AttributeRune):
+class NecromancerRuneOfMajorDeathMagic(MajorNecromancerRune):
     id = ItemUpgrade.NecromancerRuneOfMajorDeathMagic
-    profession = Profession.Necromancer
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.DeathMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB7, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x2A, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class NecromancerRuneOfMajorCurses(AttributeRune):
+class NecromancerRuneOfMajorCurses(MajorNecromancerRune):
     id = ItemUpgrade.NecromancerRuneOfMajorCurses
-    profession = Profession.Necromancer
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Curses
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB7, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x28, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class NecromancerRuneOfMajorSoulReaping(AttributeRune):
+class NecromancerRuneOfMajorSoulReaping(MajorNecromancerRune):
     id = ItemUpgrade.NecromancerRuneOfMajorSoulReaping
-    profession = Profession.Necromancer
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.SoulReaping
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB7, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x2C, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class NecromancerRuneOfSuperiorBloodMagic(AttributeRune):
+class NecromancerRuneOfSuperiorBloodMagic(SuperiorNecromancerRune):
     id = ItemUpgrade.NecromancerRuneOfSuperiorBloodMagic
-    profession = Profession.Necromancer
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.BloodMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB7, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x26, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class NecromancerRuneOfSuperiorDeathMagic(AttributeRune):
+class NecromancerRuneOfSuperiorDeathMagic(SuperiorNecromancerRune):
     id = ItemUpgrade.NecromancerRuneOfSuperiorDeathMagic
-    profession = Profession.Necromancer
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.DeathMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB7, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x2A, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class NecromancerRuneOfSuperiorCurses(AttributeRune):
+class NecromancerRuneOfSuperiorCurses(SuperiorNecromancerRune):
     id = ItemUpgrade.NecromancerRuneOfSuperiorCurses
-    profession = Profession.Necromancer
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Curses
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB7, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x28, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class NecromancerRuneOfSuperiorSoulReaping(AttributeRune):
+class NecromancerRuneOfSuperiorSoulReaping(SuperiorNecromancerRune):
     id = ItemUpgrade.NecromancerRuneOfSuperiorSoulReaping
-    profession = Profession.Necromancer
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.SoulReaping
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB7, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x2C, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
-
-@dataclass(eq=False)
-class UpgradeMinorRuneNecromancer(UpgradeRune):
-    id = ItemUpgrade.UpgradeMinorRuneNecromancer
-    profession = Profession.Necromancer
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeMajorRuneNecromancer(UpgradeRune):
-    id = ItemUpgrade.UpgradeMajorRuneNecromancer
-    profession = Profession.Necromancer
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeSuperiorRuneNecromancer(UpgradeRune):
-    id = ItemUpgrade.UpgradeSuperiorRuneNecromancer
-    profession = Profession.Necromancer
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class AppliesToMinorRuneNecromancer(AppliesToRune):
-    id = ItemUpgrade.AppliesToMinorRuneNecromancer
-    profession = Profession.Necromancer
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToMajorRuneNecromancer(AppliesToRune):
-    id = ItemUpgrade.AppliesToMajorRuneNecromancer
-    profession = Profession.Necromancer
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToSuperiorRuneNecromancer(AppliesToRune):
-    id = ItemUpgrade.AppliesToSuperiorRuneNecromancer
-    profession = Profession.Necromancer
-    mod_type = ItemUpgradeType.AppliesToRune
 
 #endregion Necromancer
 
@@ -3943,12 +8470,8 @@ class VirtuososInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xF, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xC0, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +15 (while activating skills)"
-    }
 
 @dataclass(eq=False)
 class ArtificersInsignia(Insignia):
@@ -3959,12 +8482,8 @@ class ArtificersInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x3, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0xE2, 0x53, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +3 (for each equipped Signet)"
-    }
 
 @dataclass(eq=False)
 class ProdigysInsignia(Insignia):
@@ -3975,200 +8494,133 @@ class ProdigysInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x5F, 0x4D, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x5F, 0x4D, 0x1, 0x1, 0x3, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x5F, 0x4D, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
-    descriptions = {
-        ServerLanguage.English: f"Armor +5 (while recharging 1 or more skills)\nArmor +5 (while recharging 3 or more skills)\nArmor +5 (while recharging 5 or more skills)"
-    }
+@dataclass(eq=False)
+class MinorMesmerRune(MinorAttributeRune):
+    profession = Profession.Mesmer
+    upgrade_rune_id = ItemUpgradeId.MinorMesmerRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMinorMesmerRune
 
 @dataclass(eq=False)
-class MesmerRuneOfMinorFastCasting(AttributeRune):
-    id = ItemUpgrade.MesmerRuneOfMinorFastCasting
+class MajorMesmerRune(MajorAttributeRune):
     profession = Profession.Mesmer
-    rarity = Rarity.Blue
+    upgrade_rune_id = ItemUpgradeId.MajorMesmerRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMajorMesmerRune
+
+@dataclass(eq=False)
+class SuperiorMesmerRune(SuperiorAttributeRune):
+    profession = Profession.Mesmer
+    upgrade_rune_id = ItemUpgradeId.SuperiorMesmerRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToSuperiorMesmerRune
+
+@dataclass(eq=False)
+class MesmerRuneOfMinorFastCasting(MinorMesmerRune):
+    id = ItemUpgrade.MesmerRuneOfMinorFastCasting
+    attribute = Attribute.FastCasting
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB6, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1E, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MesmerRuneOfMinorDominationMagic(AttributeRune):
+class MesmerRuneOfMinorDominationMagic(MinorMesmerRune):
     id = ItemUpgrade.MesmerRuneOfMinorDominationMagic
-    profession = Profession.Mesmer
-    rarity = Rarity.Blue
+    attribute = Attribute.DominationMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB6, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x22, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MesmerRuneOfMinorIllusionMagic(AttributeRune):
-    id = ItemUpgrade.MesmerRuneOfMinorIllusionMagic
-    profession = Profession.Mesmer
-    rarity = Rarity.Blue
+class MesmerRuneOfMinorIllusionMagic(MinorMesmerRune):
+    id = ItemUpgrade.MesmerRuneOfMinorIllusionMagic    
+    attribute = Attribute.IllusionMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB6, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x20, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MesmerRuneOfMinorInspirationMagic(AttributeRune):
+class MesmerRuneOfMinorInspirationMagic(MinorMesmerRune):
     id = ItemUpgrade.MesmerRuneOfMinorInspirationMagic
-    profession = Profession.Mesmer
-    rarity = Rarity.Blue
+    attribute = Attribute.InspirationMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB6, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x24, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MesmerRuneOfMajorFastCasting(AttributeRune):
+class MesmerRuneOfMajorFastCasting(MajorMesmerRune):
     id = ItemUpgrade.MesmerRuneOfMajorFastCasting
-    profession = Profession.Mesmer
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.FastCasting
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB6, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1E, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MesmerRuneOfMajorDominationMagic(AttributeRune):
+class MesmerRuneOfMajorDominationMagic(MajorMesmerRune):
     id = ItemUpgrade.MesmerRuneOfMajorDominationMagic
-    profession = Profession.Mesmer
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.DominationMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB6, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x22, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MesmerRuneOfMajorIllusionMagic(AttributeRune):
+class MesmerRuneOfMajorIllusionMagic(MajorMesmerRune):
     id = ItemUpgrade.MesmerRuneOfMajorIllusionMagic
-    profession = Profession.Mesmer
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.IllusionMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB6, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x20, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MesmerRuneOfMajorInspirationMagic(AttributeRune):
+class MesmerRuneOfMajorInspirationMagic(MajorMesmerRune):
     id = ItemUpgrade.MesmerRuneOfMajorInspirationMagic
-    profession = Profession.Mesmer
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.InspirationMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB6, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x24, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MesmerRuneOfSuperiorFastCasting(AttributeRune):
+class MesmerRuneOfSuperiorFastCasting(SuperiorMesmerRune):
     id = ItemUpgrade.MesmerRuneOfSuperiorFastCasting
-    profession = Profession.Mesmer
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.FastCasting
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB6, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1E, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MesmerRuneOfSuperiorDominationMagic(AttributeRune):
+class MesmerRuneOfSuperiorDominationMagic(SuperiorMesmerRune):
     id = ItemUpgrade.MesmerRuneOfSuperiorDominationMagic
-    profession = Profession.Mesmer
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.DominationMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB6, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x22, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MesmerRuneOfSuperiorIllusionMagic(AttributeRune):
+class MesmerRuneOfSuperiorIllusionMagic(SuperiorMesmerRune):
     id = ItemUpgrade.MesmerRuneOfSuperiorIllusionMagic
-    profession = Profession.Mesmer
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.IllusionMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB6, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x20, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class MesmerRuneOfSuperiorInspirationMagic(AttributeRune):
+class MesmerRuneOfSuperiorInspirationMagic(SuperiorMesmerRune):
     id = ItemUpgrade.MesmerRuneOfSuperiorInspirationMagic
-    profession = Profession.Mesmer
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.InspirationMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB6, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x24, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
-
-@dataclass(eq=False)
-class UpgradeMinorRuneMesmer(UpgradeRune):
-    id = ItemUpgrade.UpgradeMinorRuneMesmer
-    profession = Profession.Mesmer
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeMajorRuneMesmer(UpgradeRune):
-    id = ItemUpgrade.UpgradeMajorRuneMesmer
-    profession = Profession.Mesmer
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeSuperiorRuneMesmer(UpgradeRune):
-    id = ItemUpgrade.UpgradeSuperiorRuneMesmer
-    profession = Profession.Mesmer
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class AppliesToMinorRuneMesmer(AppliesToRune):
-    id = ItemUpgrade.AppliesToMinorRuneMesmer
-    profession = Profession.Mesmer
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToMajorRuneMesmer(AppliesToRune):
-    id = ItemUpgrade.AppliesToMajorRuneMesmer
-    profession = Profession.Mesmer
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToSuperiorRuneMesmer(AppliesToRune):
-    id = ItemUpgrade.AppliesToSuperiorRuneMesmer
-    profession = Profession.Mesmer
-    mod_type = ItemUpgradeType.AppliesToRune
 
 #endregion Mesmer
 
@@ -4178,65 +8630,185 @@ class AppliesToSuperiorRuneMesmer(AppliesToRune):
 class HydromancerInsignia(Insignia):
     id = ItemUpgrade.HydromancerInsignia
     profession = Profession.Elementalist
+    
+    damage_type : DamageType = DamageType.Cold
+    armor_vs_elemental : int = 10
+    armor_vs_damage : int = 10
+    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsElemental,
+            target="armor_vs_elemental",
+            fixed_value=10,
+            value_getter=property_value(
+                ArmorPlusVsElemental,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="armor_vs_damage",
+            fixed_value=10,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="damage_type",
+            fixed_value=DamageType.Cold,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.damage_type,
+            ),
+        )
+    )
+    
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x3F, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xF1, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAD, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAC, 0xA, 0xA, 0x1, 0xE1, 0x8, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (vs. elemental damage)\nArmor +10 (vs. Cold damage)"
-    }
 
 @dataclass(eq=False)
 class GeomancerInsignia(Insignia):
     id = ItemUpgrade.GeomancerInsignia
-    profession = Profession.Elementalist
+    profession = Profession.Elementalist    
+    
+    damage_type : DamageType = DamageType.Earth
+    armor_vs_elemental : int = 10
+    armor_vs_damage : int = 10
+    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsElemental,
+            target="armor_vs_elemental",
+            fixed_value=10,
+            value_getter=property_value(
+                ArmorPlusVsElemental,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="armor_vs_damage",
+            fixed_value=10,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="damage_type",
+            fixed_value=DamageType.Earth,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.damage_type,
+            ),
+        )
+    )
+    
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x3F, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xEF, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAD, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAC, 0xA, 0xA, 0x1, 0xE2, 0x8, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (vs. elemental damage)\nArmor +10 (vs. Earth damage)"
-    }
 
 @dataclass(eq=False)
 class PyromancerInsignia(Insignia):
     id = ItemUpgrade.PyromancerInsignia
     profession = Profession.Elementalist
+    
+    damage_type : DamageType = DamageType.Fire
+    armor_vs_elemental : int = 10
+    armor_vs_damage : int = 10
+    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsElemental,
+            target="armor_vs_elemental",
+            fixed_value=10,
+            value_getter=property_value(
+                ArmorPlusVsElemental,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="armor_vs_damage",
+            fixed_value=10,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="damage_type",
+            fixed_value=DamageType.Fire,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.damage_type,
+            ),
+        )
+    )
+    
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x3F, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xF0, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAD, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAC, 0xA, 0xA, 0x1, 0xE4, 0x8, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (vs. elemental damage)\nArmor +10 (vs. Fire damage)"
-    }
 
 @dataclass(eq=False)
 class AeromancerInsignia(Insignia):
     id = ItemUpgrade.AeromancerInsignia
     profession = Profession.Elementalist
+        
+    damage_type : DamageType = DamageType.Lightning
+    armor_vs_elemental : int = 10
+    armor_vs_damage : int = 10
+    
+    upgrade_info = (
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsElemental,
+            target="armor_vs_elemental",
+            fixed_value=10,
+            value_getter=property_value(
+                ArmorPlusVsElemental,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="armor_vs_damage",
+            fixed_value=10,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.armor,
+            ),
+        ),
+        fixed(
+            identifier=ModifierIdentifier.ArmorPlusVsDamage,
+            target="damage_type",
+            fixed_value=DamageType.Lightning,
+            value_getter=property_value(
+                ArmorPlusVsDamage,
+                lambda prop: prop.damage_type,
+            ),
+        )
+    )
+    
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x3F, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xEE, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
-    
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAD, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAC, 0xA, 0xA, 0x1, 0xE3, 0x8, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (vs. elemental damage)\nArmor +10 (vs. Lightning damage)"
-    }
 
 @dataclass(eq=False)
 class PrismaticInsignia(Insignia):
@@ -4247,239 +8819,159 @@ class PrismaticInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xA9, 0xA, 0xA, 0x1, 0x2E, 0x9, 0x1, 0x0, 0x1, 0x1, 0x9, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xA9, 0xA, 0xA, 0x1, 0x30, 0x9, 0x1, 0x0, 0x1, 0x1, 0x9, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xA9, 0xA, 0xA, 0x1, 0x34, 0x9, 0x1, 0x0, 0x1, 0x1, 0x9, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xA9, 0xA, 0xA, 0x1, 0x36, 0x9, 0x1, 0x0, 0x1, 0x1, 0x9, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
-    descriptions = {
-        ServerLanguage.English: f"Armor +5 (requires 9 Air Magic)\nArmor +5 (requires 9 Earth Magic)\nArmor +5 (requires 9 Fire Magic)\nArmor +5 (requires 9 Water Magic)"
-
-    }
+@dataclass(eq=False)
+class MinorElementalistRune(MinorAttributeRune):
+    profession = Profession.Elementalist
+    upgrade_rune_id = ItemUpgradeId.MinorElementalistRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMinorElementalistRune
 
 @dataclass(eq=False)
-class ElementalistRuneOfMinorEnergyStorage(AttributeRune):
-    id = ItemUpgrade.ElementalistRuneOfMinorEnergyStorage
+class MajorElementalistRune(MajorAttributeRune):
     profession = Profession.Elementalist
-    rarity = Rarity.Blue
+    upgrade_rune_id = ItemUpgradeId.MajorElementalistRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMajorElementalistRune
+
+@dataclass(eq=False)
+class SuperiorElementalistRune(SuperiorAttributeRune):
+    profession = Profession.Elementalist
+    upgrade_rune_id = ItemUpgradeId.SuperiorElementalistRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToSuperiorElementalistRune
+
+@dataclass(eq=False)
+class ElementalistRuneOfMinorEnergyStorage(MinorElementalistRune):
+    id = ItemUpgrade.ElementalistRuneOfMinorEnergyStorage
+    attribute = Attribute.EnergyStorage
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x32, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
-
 @dataclass(eq=False)
-class ElementalistRuneOfMinorFireMagic(AttributeRune):
+class ElementalistRuneOfMinorFireMagic(MinorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfMinorFireMagic
-    profession = Profession.Elementalist
-    rarity = Rarity.Blue
+    attribute = Attribute.FireMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x34, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfMinorAirMagic(AttributeRune):
+class ElementalistRuneOfMinorAirMagic(MinorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfMinorAirMagic
-    profession = Profession.Elementalist
-    rarity = Rarity.Blue
+    attribute = Attribute.AirMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x2E, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfMinorEarthMagic(AttributeRune):
+class ElementalistRuneOfMinorEarthMagic(MinorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfMinorEarthMagic
-    profession = Profession.Elementalist
-    rarity = Rarity.Blue
+    attribute = Attribute.EarthMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x30, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfMinorWaterMagic(AttributeRune):
+class ElementalistRuneOfMinorWaterMagic(MinorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfMinorWaterMagic
-    profession = Profession.Elementalist
-    rarity = Rarity.Blue
+    attribute = Attribute.WaterMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x36, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfMajorEnergyStorage(AttributeRune):
+class ElementalistRuneOfMajorEnergyStorage(MajorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfMajorEnergyStorage
-    profession = Profession.Elementalist
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.EnergyStorage
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x32, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfMajorFireMagic(AttributeRune):
+class ElementalistRuneOfMajorFireMagic(MajorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfMajorFireMagic
-    profession = Profession.Elementalist
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.FireMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x34, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfMajorAirMagic(AttributeRune):
+class ElementalistRuneOfMajorAirMagic(MajorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfMajorAirMagic
-    profession = Profession.Elementalist
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.AirMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x2E, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfMajorEarthMagic(AttributeRune):
+class ElementalistRuneOfMajorEarthMagic(MajorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfMajorEarthMagic
-    profession = Profession.Elementalist
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.EarthMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x30, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfMajorWaterMagic(AttributeRune):
+class ElementalistRuneOfMajorWaterMagic(MajorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfMajorWaterMagic
-    profession = Profession.Elementalist
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.WaterMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x36, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfSuperiorEnergyStorage(AttributeRune):
+class ElementalistRuneOfSuperiorEnergyStorage(SuperiorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfSuperiorEnergyStorage
-    profession = Profession.Elementalist
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.EnergyStorage
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x32, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfSuperiorFireMagic(AttributeRune):
+class ElementalistRuneOfSuperiorFireMagic(SuperiorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfSuperiorFireMagic
-    profession = Profession.Elementalist
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.FireMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x34, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfSuperiorAirMagic(AttributeRune):
+class ElementalistRuneOfSuperiorAirMagic(SuperiorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfSuperiorAirMagic
-    profession = Profession.Elementalist
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.AirMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x2E, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfSuperiorEarthMagic(AttributeRune):
+class ElementalistRuneOfSuperiorEarthMagic(SuperiorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfSuperiorEarthMagic
-    profession = Profession.Elementalist
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.EarthMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x30, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ElementalistRuneOfSuperiorWaterMagic(AttributeRune):
+class ElementalistRuneOfSuperiorWaterMagic(SuperiorElementalistRune):
     id = ItemUpgrade.ElementalistRuneOfSuperiorWaterMagic
-    profession = Profession.Elementalist
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.WaterMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xB8, 0x22, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x36, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
-
-@dataclass(eq=False)
-class UpgradeMinorRuneElementalist(UpgradeRune):
-    id = ItemUpgrade.UpgradeMinorRuneElementalist
-    profession = Profession.Elementalist
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeMajorRuneElementalist(UpgradeRune):
-    id = ItemUpgrade.UpgradeMajorRuneElementalist
-    profession = Profession.Elementalist
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeSuperiorRuneElementalist(UpgradeRune):
-    id = ItemUpgrade.UpgradeSuperiorRuneElementalist
-    profession = Profession.Elementalist
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class AppliesToMinorRuneElementalist(AppliesToRune):
-    id = ItemUpgrade.AppliesToMinorRuneElementalist
-    profession = Profession.Elementalist
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToMajorRuneElementalist(AppliesToRune):
-    id = ItemUpgrade.AppliesToMajorRuneElementalist
-    profession = Profession.Elementalist
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToSuperiorRuneElementalist(AppliesToRune):
-    id = ItemUpgrade.AppliesToSuperiorRuneElementalist
-    profession = Profession.Elementalist
-    mod_type = ItemUpgradeType.AppliesToRune
 
 #endregion Elementalist
 
@@ -4494,12 +8986,8 @@ class VanguardsInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB0, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAC, 0xA, 0xA, 0x1, 0xDE, 0x8, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (vs. physical damage)\nArmor +10 (vs. Blunt damage)"
-    }
 
 @dataclass(eq=False)
 class InfiltratorsInsignia(Insignia):
@@ -4510,12 +8998,8 @@ class InfiltratorsInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB0, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAC, 0xA, 0xA, 0x1, 0xDF, 0x8, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (vs. physical damage)\nArmor +10 (vs. Piercing damage)"
-    }
 
 @dataclass(eq=False)
 class SaboteursInsignia(Insignia):
@@ -4526,12 +9010,8 @@ class SaboteursInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB0, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xAC, 0xA, 0xA, 0x1, 0xE0, 0x8, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (vs. physical damage)\nArmor +10 (vs. Slashing damage)"
-    }
 
 @dataclass(eq=False)
 class NightstalkersInsignia(Insignia):
@@ -4542,200 +9022,134 @@ class NightstalkersInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xF, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xB4, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
-    descriptions = {
-        ServerLanguage.English: f"Armor +15 (while attacking)"
-    }
+@dataclass(eq=False)
+class MinorAssassinRune(MinorAttributeRune):
+    profession = Profession.Assassin
+    upgrade_rune_id = ItemUpgradeId.MinorAssassinRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMinorAssassinRune
 
 @dataclass(eq=False)
-class AssassinRuneOfMinorCriticalStrikes(AttributeRune):
-    id = ItemUpgrade.AssassinRuneOfMinorCriticalStrikes
+class MajorAssassinRune(MajorAttributeRune):
     profession = Profession.Assassin
-    rarity = Rarity.Blue
+    upgrade_rune_id = ItemUpgradeId.MajorAssassinRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMajorAssassinRune
+
+@dataclass(eq=False)
+class SuperiorAssassinRune(SuperiorAttributeRune):
+    profession = Profession.Assassin
+    upgrade_rune_id = ItemUpgradeId.SuperiorAssassinRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToSuperiorAssassinRune
+
+
+@dataclass(eq=False)
+class AssassinRuneOfMinorCriticalStrikes(MinorAssassinRune):
+    id = ItemUpgrade.AssassinRuneOfMinorCriticalStrikes
+    attribute = Attribute.CriticalStrikes
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x58, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class AssassinRuneOfMinorDaggerMastery(AttributeRune):
+class AssassinRuneOfMinorDaggerMastery(MinorAssassinRune):
     id = ItemUpgrade.AssassinRuneOfMinorDaggerMastery
-    profession = Profession.Assassin
-    rarity = Rarity.Blue
+    attribute = Attribute.DaggerMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x5A, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class AssassinRuneOfMinorDeadlyArts(AttributeRune):
+class AssassinRuneOfMinorDeadlyArts(MinorAssassinRune):
     id = ItemUpgrade.AssassinRuneOfMinorDeadlyArts
-    profession = Profession.Assassin
-    rarity = Rarity.Blue
+    attribute = Attribute.DeadlyArts
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x5C, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class AssassinRuneOfMinorShadowArts(AttributeRune):
+class AssassinRuneOfMinorShadowArts(MinorAssassinRune):
     id = ItemUpgrade.AssassinRuneOfMinorShadowArts
-    profession = Profession.Assassin
-    rarity = Rarity.Blue
+    attribute = Attribute.ShadowArts
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x5E, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class AssassinRuneOfMajorCriticalStrikes(AttributeRune):
+class AssassinRuneOfMajorCriticalStrikes(MajorAssassinRune):
     id = ItemUpgrade.AssassinRuneOfMajorCriticalStrikes
-    profession = Profession.Assassin
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.CriticalStrikes
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x58, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class AssassinRuneOfMajorDaggerMastery(AttributeRune):
+class AssassinRuneOfMajorDaggerMastery(MajorAssassinRune):
     id = ItemUpgrade.AssassinRuneOfMajorDaggerMastery
-    profession = Profession.Assassin
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.DaggerMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x5A, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class AssassinRuneOfMajorDeadlyArts(AttributeRune):
+class AssassinRuneOfMajorDeadlyArts(MajorAssassinRune):
     id = ItemUpgrade.AssassinRuneOfMajorDeadlyArts
-    profession = Profession.Assassin
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.DeadlyArts
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x5C, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class AssassinRuneOfMajorShadowArts(AttributeRune):
+class AssassinRuneOfMajorShadowArts(MajorAssassinRune):
     id = ItemUpgrade.AssassinRuneOfMajorShadowArts
-    profession = Profession.Assassin
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.ShadowArts
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x5E, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class AssassinRuneOfSuperiorCriticalStrikes(AttributeRune):
+class AssassinRuneOfSuperiorCriticalStrikes(SuperiorAssassinRune):
     id = ItemUpgrade.AssassinRuneOfSuperiorCriticalStrikes
-    profession = Profession.Assassin
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.CriticalStrikes
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x58, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class AssassinRuneOfSuperiorDaggerMastery(AttributeRune):
+class AssassinRuneOfSuperiorDaggerMastery(SuperiorAssassinRune):
     id = ItemUpgrade.AssassinRuneOfSuperiorDaggerMastery
-    profession = Profession.Assassin
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.DaggerMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x5A, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class AssassinRuneOfSuperiorDeadlyArts(AttributeRune):
+class AssassinRuneOfSuperiorDeadlyArts(SuperiorAssassinRune):
     id = ItemUpgrade.AssassinRuneOfSuperiorDeadlyArts
-    profession = Profession.Assassin
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.DeadlyArts
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x5C, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class AssassinRuneOfSuperiorShadowArts(AttributeRune):
+class AssassinRuneOfSuperiorShadowArts(SuperiorAssassinRune):
     id = ItemUpgrade.AssassinRuneOfSuperiorShadowArts
-    profession = Profession.Assassin
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.ShadowArts
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x5E, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
-
-@dataclass(eq=False)
-class UpgradeMinorRuneAssassin(UpgradeRune):
-    id = ItemUpgrade.UpgradeMinorRuneAssassin
-    profession = Profession.Assassin
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeMajorRuneAssassin(UpgradeRune):
-    id = ItemUpgrade.UpgradeMajorRuneAssassin
-    profession = Profession.Assassin
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeSuperiorRuneAssassin(UpgradeRune):
-    id = ItemUpgrade.UpgradeSuperiorRuneAssassin
-    profession = Profession.Assassin
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class AppliesToMinorRuneAssassin(AppliesToRune):
-    id = ItemUpgrade.AppliesToMinorRuneAssassin
-    profession = Profession.Assassin
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToMajorRuneAssassin(AppliesToRune):
-    id = ItemUpgrade.AppliesToMajorRuneAssassin
-    profession = Profession.Assassin
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToSuperiorRuneAssassin(AppliesToRune):
-    id = ItemUpgrade.AppliesToSuperiorRuneAssassin
-    profession = Profession.Assassin
-    mod_type = ItemUpgradeType.AppliesToRune
 
 #endregion Assassin
 
@@ -4750,13 +9164,8 @@ class ShamansInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x82, 0x7D, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x82, 0x7D, 0x1, 0x1, 0x2, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x82, 0x7D, 0x1, 0x1, 0x3, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +5 (while you control 1 or more Spirits)\nArmor +5 (while you control 2 or more Spirits)\nArmor +5 (while you control 3 or more Spirits)"
-
-    }
 
 @dataclass(eq=False)
 class GhostForgeInsignia(Insignia):
@@ -4767,13 +9176,8 @@ class GhostForgeInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xF, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x9C, 0x4D, 0xA, 0x1, 0xBA, 0x4, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +15 (while affected by a Weapon Spell)"
-
-    }
 
 @dataclass(eq=False)
 class MysticsInsignia(Insignia):
@@ -4781,203 +9185,135 @@ class MysticsInsignia(Insignia):
     profession = Profession.Ritualist
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x44, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0x7, 0x59, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xF, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0xC0, 0xA, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
-    descriptions = {
-        ServerLanguage.English: f"Armor +15 (while activating skills)"
-    }
+@dataclass(eq=False)
+class MinorRitualistRune(MinorAttributeRune):
+    profession = Profession.Ritualist
+    upgrade_rune_id = ItemUpgradeId.MinorRitualistRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMinorRitualistRune
 
 @dataclass(eq=False)
-class RitualistRuneOfMinorChannelingMagic(AttributeRune):
-    id = ItemUpgrade.RitualistRuneOfMinorChannelingMagic
+class MajorRitualistRune(MajorAttributeRune):
     profession = Profession.Ritualist
-    rarity = Rarity.Blue
+    upgrade_rune_id = ItemUpgradeId.MajorRitualistRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMajorRitualistRune
+
+@dataclass(eq=False)
+class SuperiorRitualistRune(SuperiorAttributeRune):
+    profession = Profession.Ritualist
+    upgrade_rune_id = ItemUpgradeId.SuperiorRitualistRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToSuperiorRitualistRune
+    
+@dataclass(eq=False)
+class RitualistRuneOfMinorChannelingMagic(MinorRitualistRune):
+    id = ItemUpgrade.RitualistRuneOfMinorChannelingMagic
+    attribute = Attribute.ChannelingMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xC0, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x66, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RitualistRuneOfMinorRestorationMagic(AttributeRune):
+class RitualistRuneOfMinorRestorationMagic(MinorRitualistRune):
     id = ItemUpgrade.RitualistRuneOfMinorRestorationMagic
-    profession = Profession.Ritualist
-    rarity = Rarity.Blue
+    attribute = Attribute.RestorationMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xC0, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x64, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RitualistRuneOfMinorCommuning(AttributeRune):
+class RitualistRuneOfMinorCommuning(MinorRitualistRune):
     id = ItemUpgrade.RitualistRuneOfMinorCommuning
-    profession = Profession.Ritualist
-    rarity = Rarity.Blue
+    attribute = Attribute.Communing
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xC0, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x60, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RitualistRuneOfMinorSpawningPower(AttributeRune):
+class RitualistRuneOfMinorSpawningPower(MinorRitualistRune):
     id = ItemUpgrade.RitualistRuneOfMinorSpawningPower
-    profession = Profession.Ritualist
-    rarity = Rarity.Blue
+    attribute = Attribute.SpawningPower
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xC0, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x62, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RitualistRuneOfMajorChannelingMagic(AttributeRune):
+class RitualistRuneOfMajorChannelingMagic(MajorRitualistRune):
     id = ItemUpgrade.RitualistRuneOfMajorChannelingMagic
-    profession = Profession.Ritualist
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.ChannelingMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xC0, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x66, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RitualistRuneOfMajorRestorationMagic(AttributeRune):
+class RitualistRuneOfMajorRestorationMagic(MajorRitualistRune):
     id = ItemUpgrade.RitualistRuneOfMajorRestorationMagic
-    profession = Profession.Ritualist
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.RestorationMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xC0, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x64, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RitualistRuneOfMajorCommuning(AttributeRune):
+class RitualistRuneOfMajorCommuning(MajorRitualistRune):
     id = ItemUpgrade.RitualistRuneOfMajorCommuning
-    profession = Profession.Ritualist
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Communing
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xC0, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x60, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RitualistRuneOfMajorSpawningPower(AttributeRune):
+class RitualistRuneOfMajorSpawningPower(MajorRitualistRune):
     id = ItemUpgrade.RitualistRuneOfMajorSpawningPower
-    profession = Profession.Ritualist
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.SpawningPower
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xC0, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x62, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RitualistRuneOfSuperiorChannelingMagic(AttributeRune):
+class RitualistRuneOfSuperiorChannelingMagic(SuperiorRitualistRune):
     id = ItemUpgrade.RitualistRuneOfSuperiorChannelingMagic
-    profession = Profession.Ritualist
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.ChannelingMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xC0, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x66, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RitualistRuneOfSuperiorRestorationMagic(AttributeRune):
+class RitualistRuneOfSuperiorRestorationMagic(SuperiorRitualistRune):
     id = ItemUpgrade.RitualistRuneOfSuperiorRestorationMagic
-    profession = Profession.Ritualist
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.RestorationMagic
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xC0, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x64, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RitualistRuneOfSuperiorCommuning(AttributeRune):
+class RitualistRuneOfSuperiorCommuning(SuperiorRitualistRune):
     id = ItemUpgrade.RitualistRuneOfSuperiorCommuning
-    profession = Profession.Ritualist
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Communing
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xC0, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x60, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class RitualistRuneOfSuperiorSpawningPower(AttributeRune):
+class RitualistRuneOfSuperiorSpawningPower(SuperiorRitualistRune):
     id = ItemUpgrade.RitualistRuneOfSuperiorSpawningPower
-    profession = Profession.Ritualist
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.SpawningPower
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0xC0, 0x55, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x62, 0x9, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
-
-@dataclass(eq=False)
-class UpgradeMinorRuneRitualist(UpgradeRune):
-    id = ItemUpgrade.UpgradeMinorRuneRitualist
-    profession = Profession.Ritualist
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeMajorRuneRitualist(UpgradeRune):
-    id = ItemUpgrade.UpgradeMajorRuneRitualist
-    profession = Profession.Ritualist
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeSuperiorRuneRitualist(UpgradeRune):
-    id = ItemUpgrade.UpgradeSuperiorRuneRitualist
-    profession = Profession.Ritualist
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class AppliesToMinorRuneRitualist(AppliesToRune):
-    id = ItemUpgrade.AppliesToMinorRuneRitualist
-    profession = Profession.Ritualist
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToMajorRuneRitualist(AppliesToRune):
-    id = ItemUpgrade.AppliesToMajorRuneRitualist
-    profession = Profession.Ritualist
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToSuperiorRuneRitualist(AppliesToRune):
-    id = ItemUpgrade.AppliesToSuperiorRuneRitualist
-    profession = Profession.Ritualist
-    mod_type = ItemUpgradeType.AppliesToRune
 
 #endregion Ritualist
 
@@ -4990,15 +9326,9 @@ class WindwalkerInsignia(Insignia):
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x43, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xEC, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
-    
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x9E, 0x4D, 0xA, 0x1, 0xB6, 0x4, 0x1, 0x0, 0x1, 0x1, 0x1, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x9E, 0x4D, 0xA, 0x1, 0xB6, 0x4, 0x1, 0x0, 0x1, 0x1, 0x2, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x9E, 0x4D, 0xA, 0x1, 0xB6, 0x4, 0x1, 0x0, 0x1, 0x1, 0x3, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0x5, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x9E, 0x4D, 0xA, 0x1, 0xB6, 0x4, 0x1, 0x0, 0x1, 0x1, 0x4, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
-
-    descriptions = {
-        ServerLanguage.English: f"Armor +5 (while affected by 1 or more Enchantment Spells)\nArmor +5 (while affected by 2 or more Enchantment Spells)\nArmor +5 (while affected by 3 or more Enchantment Spells)\nArmor +5 (while affected by 4 or more Enchantment Spells)"
-
-    }
 
 @dataclass(eq=False)
 class ForsakenInsignia(Insignia):
@@ -5006,203 +9336,135 @@ class ForsakenInsignia(Insignia):
     profession = Profession.Dervish
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x30, 0xA, 0xA, 0x1, 0x1, 0x81, 0x43, 0x59, 0x1, 0x0, 0xB, 0x1, 0x1, 0x81, 0xEB, 0x58, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x9D, 0x4D, 0xA, 0x1, 0xB6, 0x4, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (while not affected by an Enchantment Spell)"
-    }
+@dataclass(eq=False)
+class MinorDervishRune(MinorAttributeRune):
+    profession = Profession.Dervish
+    upgrade_rune_id = ItemUpgradeId.MinorDervishRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMinorDervishRune
 
 @dataclass(eq=False)
-class DervishRuneOfMinorMysticism(AttributeRune):
-    id = ItemUpgrade.DervishRuneOfMinorMysticism
+class MajorDervishRune(MajorAttributeRune):
     profession = Profession.Dervish
-    rarity = Rarity.Blue
+    upgrade_rune_id = ItemUpgradeId.MajorDervishRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMajorDervishRune
+
+@dataclass(eq=False)
+class SuperiorDervishRune(SuperiorAttributeRune):
+    profession = Profession.Dervish
+    upgrade_rune_id = ItemUpgradeId.SuperiorDervishRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToSuperiorDervishRune
+    
+@dataclass(eq=False)
+class DervishRuneOfMinorMysticism(MinorDervishRune):
+    id = ItemUpgrade.DervishRuneOfMinorMysticism
+    attribute = Attribute.Mysticism
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x71, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x39, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class DervishRuneOfMinorEarthPrayers(AttributeRune):
+class DervishRuneOfMinorEarthPrayers(MinorDervishRune):
     id = ItemUpgrade.DervishRuneOfMinorEarthPrayers
-    profession = Profession.Dervish
-    rarity = Rarity.Blue
+    attribute = Attribute.EarthPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x71, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x37, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class DervishRuneOfMinorScytheMastery(AttributeRune):
+class DervishRuneOfMinorScytheMastery(MinorDervishRune):
     id = ItemUpgrade.DervishRuneOfMinorScytheMastery
-    profession = Profession.Dervish
-    rarity = Rarity.Blue
+    attribute = Attribute.ScytheMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x71, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x22, 0x11, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class DervishRuneOfMinorWindPrayers(AttributeRune):
+class DervishRuneOfMinorWindPrayers(MinorDervishRune):
     id = ItemUpgrade.DervishRuneOfMinorWindPrayers
-    profession = Profession.Dervish
-    rarity = Rarity.Blue
+    attribute = Attribute.WindPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x71, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x35, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class DervishRuneOfMajorMysticism(AttributeRune):
+class DervishRuneOfMajorMysticism(MajorDervishRune):
     id = ItemUpgrade.DervishRuneOfMajorMysticism
-    profession = Profession.Dervish
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Mysticism
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x71, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x39, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class DervishRuneOfMajorEarthPrayers(AttributeRune):
+class DervishRuneOfMajorEarthPrayers(MajorDervishRune):
     id = ItemUpgrade.DervishRuneOfMajorEarthPrayers
-    profession = Profession.Dervish
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.EarthPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x71, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x37, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class DervishRuneOfMajorScytheMastery(AttributeRune):
+class DervishRuneOfMajorScytheMastery(MajorDervishRune):
     id = ItemUpgrade.DervishRuneOfMajorScytheMastery
-    profession = Profession.Dervish
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.ScytheMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x71, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x22, 0x11, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class DervishRuneOfMajorWindPrayers(AttributeRune):
+class DervishRuneOfMajorWindPrayers(MajorDervishRune):
     id = ItemUpgrade.DervishRuneOfMajorWindPrayers
-    profession = Profession.Dervish
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.WindPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x71, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x35, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class DervishRuneOfSuperiorMysticism(AttributeRune):
+class DervishRuneOfSuperiorMysticism(SuperiorDervishRune):
     id = ItemUpgrade.DervishRuneOfSuperiorMysticism
-    profession = Profession.Dervish
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Mysticism
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x71, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x39, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class DervishRuneOfSuperiorEarthPrayers(AttributeRune):
+class DervishRuneOfSuperiorEarthPrayers(SuperiorDervishRune):
     id = ItemUpgrade.DervishRuneOfSuperiorEarthPrayers
-    profession = Profession.Dervish
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.EarthPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x71, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x37, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class DervishRuneOfSuperiorScytheMastery(AttributeRune):
+class DervishRuneOfSuperiorScytheMastery(SuperiorDervishRune):
     id = ItemUpgrade.DervishRuneOfSuperiorScytheMastery
-    profession = Profession.Dervish
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.ScytheMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x71, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x22, 0x11, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class DervishRuneOfSuperiorWindPrayers(AttributeRune):
+class DervishRuneOfSuperiorWindPrayers(SuperiorDervishRune):
     id = ItemUpgrade.DervishRuneOfSuperiorWindPrayers
-    profession = Profession.Dervish
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.WindPrayers
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x71, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x35, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
-
-@dataclass(eq=False)
-class UpgradeMinorRuneDervish(UpgradeRune):
-    id = ItemUpgrade.UpgradeMinorRuneDervish
-    profession = Profession.Dervish
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeMajorRuneDervish(UpgradeRune):
-    id = ItemUpgrade.UpgradeMajorRuneDervish
-    profession = Profession.Dervish
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeSuperiorRuneDervish(UpgradeRune):
-    id = ItemUpgrade.UpgradeSuperiorRuneDervish
-    profession = Profession.Dervish
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class AppliesToMinorRuneDervish(AppliesToRune):
-    id = ItemUpgrade.AppliesToMinorRuneDervish
-    profession = Profession.Dervish
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToMajorRuneDervish(AppliesToRune):
-    id = ItemUpgrade.AppliesToMajorRuneDervish
-    profession = Profession.Dervish
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToSuperiorRuneDervish(AppliesToRune):
-    id = ItemUpgrade.AppliesToSuperiorRuneDervish
-    profession = Profession.Dervish
-    mod_type = ItemUpgradeType.AppliesToRune
 
 #endregion Dervish
 
@@ -5217,606 +9479,192 @@ class CenturionsInsignia(Insignia):
 
     
     def create_encoded_description(self) -> GWStringEncoded:
-        fallback = self.descriptions.get(ServerLanguage.English, f"no encoded description ({self.__class__.__name__})")
+        fallback = f"{_humanize_identifier(self.__class__.__name__)} (no encoded description)"
         return GWStringEncoded(bytes([0x2, 0x0, 0x3C, 0xA, 0xA, 0x1, 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, 0xA, 0x1, 0x1, 0x0, 0x2, 0x0, 0x3E, 0xA, 0xA, 0x1, 0xA8, 0xA, 0xA, 0x1, 0x1, 0x81, 0x60, 0x4D, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1]), fallback)
 
-    descriptions = {
-        ServerLanguage.English: f"Armor +10 (while affected by a Shout, Echo, or Chant)"
-    }
+@dataclass(eq=False)
+class MinorParagonRune(MinorAttributeRune):
+    profession = Profession.Paragon
+    upgrade_rune_id = ItemUpgradeId.MinorParagonRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMinorParagonRune
 
 @dataclass(eq=False)
-class ParagonRuneOfMinorLeadership(AttributeRune):
-    id = ItemUpgrade.ParagonRuneOfMinorLeadership
+class MajorParagonRune(MajorAttributeRune):
     profession = Profession.Paragon
-    rarity = Rarity.Blue
+    upgrade_rune_id = ItemUpgradeId.MajorParagonRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToMajorParagonRune
+
+@dataclass(eq=False)
+class SuperiorParagonRune(SuperiorAttributeRune):
+    profession = Profession.Paragon
+    upgrade_rune_id = ItemUpgradeId.SuperiorParagonRune
+    applies_to_rune_id = ItemUpgradeId.AppliesToSuperiorParagonRune
+    
+@dataclass(eq=False)
+class ParagonRuneOfMinorLeadership(MinorParagonRune):
+    id = ItemUpgrade.ParagonRuneOfMinorLeadership
+    attribute = Attribute.Leadership
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x72, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x33, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ParagonRuneOfMinorMotivation(AttributeRune):
+class ParagonRuneOfMinorMotivation(MinorParagonRune):
     id = ItemUpgrade.ParagonRuneOfMinorMotivation
-    profession = Profession.Paragon
-    rarity = Rarity.Blue
+    attribute = Attribute.Motivation
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x72, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x1A, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ParagonRuneOfMinorCommand(AttributeRune):
+class ParagonRuneOfMinorCommand(MinorParagonRune):
     id = ItemUpgrade.ParagonRuneOfMinorCommand
-    profession = Profession.Paragon
-    rarity = Rarity.Blue
+    attribute = Attribute.Command
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x72, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0xD5, 0x6, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ParagonRuneOfMinorSpearMastery(AttributeRune):
+class ParagonRuneOfMinorSpearMastery(MinorParagonRune):
     id = ItemUpgrade.ParagonRuneOfMinorSpearMastery
-    profession = Profession.Paragon
-    rarity = Rarity.Blue
+    attribute = Attribute.SpearMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x72, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x20, 0x11, 0x1, 0x0, 0xB, 0x1, 0x5A, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ParagonRuneOfMajorLeadership(AttributeRune):
+class ParagonRuneOfMajorLeadership(MajorParagonRune):
     id = ItemUpgrade.ParagonRuneOfMajorLeadership
-    profession = Profession.Paragon
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Leadership
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x72, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x33, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ParagonRuneOfMajorMotivation(AttributeRune):
+class ParagonRuneOfMajorMotivation(MajorParagonRune):
     id = ItemUpgrade.ParagonRuneOfMajorMotivation
-    profession = Profession.Paragon
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Motivation
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x72, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x1A, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ParagonRuneOfMajorCommand(AttributeRune):
+class ParagonRuneOfMajorCommand(MajorParagonRune):
     id = ItemUpgrade.ParagonRuneOfMajorCommand
-    profession = Profession.Paragon
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Command
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x72, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0xD5, 0x6, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ParagonRuneOfMajorSpearMastery(AttributeRune):
+class ParagonRuneOfMajorSpearMastery(MajorParagonRune):
     id = ItemUpgrade.ParagonRuneOfMajorSpearMastery
-    profession = Profession.Paragon
-    rarity = Rarity.Purple
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.SpearMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x72, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x20, 0x11, 0x1, 0x0, 0xB, 0x1, 0x5B, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ParagonRuneOfSuperiorLeadership(AttributeRune):
+class ParagonRuneOfSuperiorLeadership(SuperiorParagonRune):
     id = ItemUpgrade.ParagonRuneOfSuperiorLeadership
-    profession = Profession.Paragon
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Leadership
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x72, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x33, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ParagonRuneOfSuperiorMotivation(AttributeRune):
+class ParagonRuneOfSuperiorMotivation(SuperiorParagonRune):
     id = ItemUpgrade.ParagonRuneOfSuperiorMotivation
-    profession = Profession.Paragon
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Motivation
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x72, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x1A, 0x12, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ParagonRuneOfSuperiorCommand(AttributeRune):
+class ParagonRuneOfSuperiorCommand(SuperiorParagonRune):
     id = ItemUpgrade.ParagonRuneOfSuperiorCommand
-    profession = Profession.Paragon
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.Command
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x72, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0xD5, 0x6, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
 
 
 @dataclass(eq=False)
-class ParagonRuneOfSuperiorSpearMastery(AttributeRune):
+class ParagonRuneOfSuperiorSpearMastery(SuperiorParagonRune):
     id = ItemUpgrade.ParagonRuneOfSuperiorSpearMastery
-    profession = Profession.Paragon
-    rarity = Rarity.Gold
-
-    property_identifiers = [
-        ModifierIdentifier.HealthMinus
-    ]
+    attribute = Attribute.SpearMastery
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + bytes([0x33, 0xA, 0xA, 0x1, 0x1, 0x81, 0x72, 0x1C, 0x1, 0x0, 0xB, 0x1, 0x8, 0x1, 0xA, 0x1, 0x8B, 0xA, 0xA, 0x1, 0x1, 0x81, 0x20, 0x11, 0x1, 0x0, 0xB, 0x1, 0x5C, 0xA, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x1, 0x0]), _humanize_identifier(self.__class__.__name__))
-
-
-@dataclass(eq=False)
-class UpgradeMinorRuneParagon(UpgradeRune):
-    id = ItemUpgrade.UpgradeMinorRuneParagon
-    profession = Profession.Paragon
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeMajorRuneParagon(UpgradeRune):
-    id = ItemUpgrade.UpgradeMajorRuneParagon
-    profession = Profession.Paragon
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class UpgradeSuperiorRuneParagon(UpgradeRune):
-    id = ItemUpgrade.UpgradeSuperiorRuneParagon
-    profession = Profession.Paragon
-    mod_type = ItemUpgradeType.UpgradeRune
-
-@dataclass(eq=False)
-class AppliesToMinorRuneParagon(AppliesToRune):
-    id = ItemUpgrade.AppliesToMinorRuneParagon
-    profession = Profession.Paragon
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToMajorRuneParagon(AppliesToRune):
-    id = ItemUpgrade.AppliesToMajorRuneParagon
-    profession = Profession.Paragon
-    mod_type = ItemUpgradeType.AppliesToRune
-
-@dataclass(eq=False)
-class AppliesToSuperiorRuneParagon(AppliesToRune):
-    id = ItemUpgrade.AppliesToSuperiorRuneParagon
-    profession = Profession.Paragon
-    mod_type = ItemUpgradeType.AppliesToRune
-
+    
 #endregion Paragon
 
 #endregion Armor Upgrades
 
+def _get_concrete_upgrade_types(
+    base_type: type[Upgrade],
+    excluded_types: tuple[type[Upgrade], ...] = (),
+    class_filter: Callable[[type[Upgrade]], bool] | None = None,
+) -> list[type[Upgrade]]:
+    classes = tuple(
+        cls
+        for cls in globals().values()
+        if isinstance(cls, type)
+        and issubclass(cls, base_type)
+        and cls not in (Upgrade, Inherent, *excluded_types)
+        and cls.__module__ == __name__
+        and (class_filter is None or class_filter(cls))
+    )
+    base_classes = set(classes)
+
+    return [
+        cls
+        for cls in classes
+        if not any(
+            subclass is not cls
+            and subclass in base_classes
+            and issubclass(subclass, cls)
+            for subclass in classes
+        )
+    ]
+
+
 _UPGRADES: list[type[Upgrade]] = [
-    IcyUpgrade,
-    EbonUpgrade,
-    ShockingUpgrade,
-    FieryUpgrade,
-    BarbedUpgrade,
-    CripplingUpgrade,
-    CruelUpgrade,
-    PoisonousUpgrade,
-    SilencingUpgrade,
-    FuriousUpgrade,
-    HeavyUpgrade,
-    ZealousUpgrade,
-    VampiricUpgrade,
-    SunderingUpgrade,
-    DefensiveUpgrade,
-    InsightfulUpgrade,
-    HaleUpgrade,
-    OfDefenseUpgrade,
-    OfWardingUpgrade,
-    OfShelterUpgrade,
-    OfSlayingUpgrade,
-    OfFortitudeUpgrade,
-    OfEnchantingUpgrade,
-    OfTheProfessionUpgrade,
-    OfAxeMasteryUpgrade,
-    OfMarksmanshipUpgrade,
-    OfDaggerMasteryUpgrade,
-    OfHammerMasteryUpgrade,
-    OfScytheMasteryUpgrade,
-    OfSpearMasteryUpgrade,
-    OfSwordsmanshipUpgrade,
-    OfAttributeUpgrade,
-    OfMasteryUpgrade,
-    SwiftUpgrade,
-    AdeptUpgrade,
-    OfMemoryUpgrade,
-    OfQuickeningUpgrade,
-    OfAptitudeUpgrade,
-    OfDevotionUpgrade,
-    OfValorUpgrade,
-    OfEnduranceUpgrade,
-    OfSwiftnessUpgrade,
-    
-    BeJustAndFearNot,
-    DownButNotOut,
-    FaithIsMyShield,
-    ForgetMeNot,
-    HailToTheKing,
-    IgnoranceIsBliss,
-    KnowingIsHalfTheBattle,
-    LifeIsPain,
-    LiveForToday,
-    ManForAllSeasons,
-    MightMakesRight,
-    SerenityNow,
-    SurvivalOfTheFittest,
-    BrawnOverBrains,
-    DanceWithDeath,
-    DontFearTheReaper,
-    DontThinkTwice,
-    GuidedByFate,
-    StrengthAndHonor,
-    ToThePain,
-    TooMuchInformation,
-    VengeanceIsMine,
-    IHaveThePower,
-    LetTheMemoryLiveAgain,
-    CastOutTheUnclean,
-    FearCutsDeeper,
-    ICanSeeClearlyNow,
-    LeafOnTheWind,
-    LikeARollingStone,
-    LuckOfTheDraw,
-    MasterOfMyDomain,
-    NotTheFace,
-    NothingToFear,
-    OnlyTheStrongSurvive,
-    PureOfHeart,
-    RidersOnTheStorm,
-    RunForYourLife,
-    ShelteredByFaith,
-    SleepNowInTheFire,
-    SoundnessOfMind,
-    StrengthOfBody,
-    SwiftAsTheWind,
-    TheRiddleOfSteel,
-    ThroughThickAndThin,
-    MeasureForMeasure,
-    ShowMeTheMoney,
-    AptitudeNotAttitude,
-    DontCallItAComeback,
-    HaleAndHearty,
-    HaveFaith,
-    IAmSorrow,
-    SeizeTheDay,
-        
-    # No Profession
-    SurvivorInsignia,
-    RadiantInsignia,
-    StalwartInsignia,
-    BrawlersInsignia,
-    BlessedInsignia,
-    HeraldsInsignia,
-    SentrysInsignia,
-    
-    # Warrior
-    KnightsInsignia,
-    LieutenantsInsignia,
-    StonefistInsignia,
-    DreadnoughtInsignia,
-    SentinelsInsignia,
-    
-    # Ranger
-    FrostboundInsignia,
-    PyreboundInsignia,
-    StormboundInsignia,
-    ScoutsInsignia,
-    EarthboundInsignia,
-    BeastmastersInsignia,
-    
-    # Monk
-    WanderersInsignia,
-    DisciplesInsignia,
-    AnchoritesInsignia,
-    
-    # Necromancer
-    BloodstainedInsignia,
-    TormentorsInsignia,
-    BonelaceInsignia,
-    MinionMastersInsignia,
-    BlightersInsignia,
-    UndertakersInsignia,
-    
-    # Mesmer 
-    VirtuososInsignia,
-    ArtificersInsignia,
-    ProdigysInsignia,
-    
-    # Elementalist
-    HydromancerInsignia,
-    GeomancerInsignia,
-    PyromancerInsignia,
-    AeromancerInsignia,
-    PrismaticInsignia,
-    
-    # Assassin
-    VanguardsInsignia,
-    InfiltratorsInsignia,
-    SaboteursInsignia,
-    NightstalkersInsignia,
-    
-    # Ritualist
-    ShamansInsignia,
-    GhostForgeInsignia,
-    MysticsInsignia,
-    
-    # Dervish
-    WindwalkerInsignia,
-    ForsakenInsignia,
-    
-    # Paragon
-    CenturionsInsignia,    
-    
-    #No Profession
-    RuneOfMinorVigor,
-    RuneOfMinorVigor2,
-    RuneOfVitae,
-    RuneOfAttunement,
-    RuneOfMajorVigor,
-    RuneOfRecovery,
-    RuneOfRestoration,
-    RuneOfClarity,
-    RuneOfPurity,
-    RuneOfSuperiorVigor,
-    
-    # Warrior    
-    WarriorRuneOfMinorAbsorption,
-    WarriorRuneOfMinorTactics,
-    WarriorRuneOfMinorStrength,
-    WarriorRuneOfMinorAxeMastery,
-    WarriorRuneOfMinorHammerMastery,
-    WarriorRuneOfMinorSwordsmanship,
-    WarriorRuneOfMajorAbsorption,
-    WarriorRuneOfMajorTactics,
-    WarriorRuneOfMajorStrength,
-    WarriorRuneOfMajorAxeMastery,
-    WarriorRuneOfMajorHammerMastery,
-    WarriorRuneOfMajorSwordsmanship,
-    WarriorRuneOfSuperiorAbsorption,
-    WarriorRuneOfSuperiorTactics,
-    WarriorRuneOfSuperiorStrength,
-    WarriorRuneOfSuperiorAxeMastery,
-    WarriorRuneOfSuperiorHammerMastery,
-    WarriorRuneOfSuperiorSwordsmanship,
-    
-    UpgradeMinorRuneWarrior,
-    UpgradeMajorRuneWarrior,
-    UpgradeSuperiorRuneWarrior,
-    AppliesToMinorRuneWarrior,
-    AppliesToMajorRuneWarrior,
-    AppliesToSuperiorRuneWarrior,
-    
-    # Ranger        
-    RangerRuneOfMinorWildernessSurvival,
-    RangerRuneOfMinorExpertise,
-    RangerRuneOfMinorBeastMastery,
-    RangerRuneOfMinorMarksmanship,
-    RangerRuneOfMajorWildernessSurvival,
-    RangerRuneOfMajorExpertise,
-    RangerRuneOfMajorBeastMastery,
-    RangerRuneOfMajorMarksmanship,
-    RangerRuneOfSuperiorWildernessSurvival,
-    RangerRuneOfSuperiorExpertise,
-    RangerRuneOfSuperiorBeastMastery,
-    RangerRuneOfSuperiorMarksmanship,
-    
-    UpgradeMinorRuneRanger,
-    UpgradeMajorRuneRanger,
-    UpgradeSuperiorRuneRanger,
-    AppliesToMinorRuneRanger,
-    AppliesToMajorRuneRanger,
-    AppliesToSuperiorRuneRanger,
-    
-    # Monk    
-    MonkRuneOfMinorHealingPrayers,
-    MonkRuneOfMinorSmitingPrayers,
-    MonkRuneOfMinorProtectionPrayers,
-    MonkRuneOfMinorDivineFavor,
-    MonkRuneOfMajorHealingPrayers,
-    MonkRuneOfMajorSmitingPrayers,
-    MonkRuneOfMajorProtectionPrayers,
-    MonkRuneOfMajorDivineFavor,
-    MonkRuneOfSuperiorHealingPrayers,
-    MonkRuneOfSuperiorSmitingPrayers,
-    MonkRuneOfSuperiorProtectionPrayers,
-    MonkRuneOfSuperiorDivineFavor,
-    
-    UpgradeMinorRuneMonk,
-    UpgradeMajorRuneMonk,
-    UpgradeSuperiorRuneMonk,
-    AppliesToMinorRuneMonk,
-    AppliesToMajorRuneMonk,
-    AppliesToSuperiorRuneMonk,
-    
-    # Necromancer
-    NecromancerRuneOfMinorBloodMagic,
-    NecromancerRuneOfMinorDeathMagic,
-    NecromancerRuneOfMinorCurses,
-    NecromancerRuneOfMinorSoulReaping,
-    NecromancerRuneOfMajorBloodMagic,
-    NecromancerRuneOfMajorDeathMagic,
-    NecromancerRuneOfMajorCurses,
-    NecromancerRuneOfMajorSoulReaping,
-    NecromancerRuneOfSuperiorBloodMagic,
-    NecromancerRuneOfSuperiorDeathMagic,
-    NecromancerRuneOfSuperiorCurses,
-    NecromancerRuneOfSuperiorSoulReaping,
-    
-    UpgradeMinorRuneNecromancer,
-    UpgradeMajorRuneNecromancer,
-    UpgradeSuperiorRuneNecromancer,
-    AppliesToMinorRuneNecromancer,
-    AppliesToMajorRuneNecromancer,
-    AppliesToSuperiorRuneNecromancer,
-    
-    # Mesmer 
-    MesmerRuneOfMinorFastCasting,
-    MesmerRuneOfMinorDominationMagic,
-    MesmerRuneOfMinorIllusionMagic,
-    MesmerRuneOfMinorInspirationMagic,
-    MesmerRuneOfMajorFastCasting,
-    MesmerRuneOfMajorDominationMagic,
-    MesmerRuneOfMajorIllusionMagic,
-    MesmerRuneOfMajorInspirationMagic,
-    MesmerRuneOfSuperiorFastCasting,
-    MesmerRuneOfSuperiorDominationMagic,
-    MesmerRuneOfSuperiorIllusionMagic,
-    MesmerRuneOfSuperiorInspirationMagic,
-    
-    UpgradeMinorRuneMesmer,
-    UpgradeMajorRuneMesmer,
-    UpgradeSuperiorRuneMesmer,
-    AppliesToMinorRuneMesmer,
-    AppliesToMajorRuneMesmer,
-    AppliesToSuperiorRuneMesmer,
-    
-    # Elementalist
-    ElementalistRuneOfMinorEnergyStorage,
-    ElementalistRuneOfMinorFireMagic,
-    ElementalistRuneOfMinorAirMagic,
-    ElementalistRuneOfMinorEarthMagic,
-    ElementalistRuneOfMinorWaterMagic,
-    ElementalistRuneOfMajorEnergyStorage,
-    ElementalistRuneOfMajorFireMagic,
-    ElementalistRuneOfMajorAirMagic,
-    ElementalistRuneOfMajorEarthMagic,
-    ElementalistRuneOfMajorWaterMagic,
-    ElementalistRuneOfSuperiorEnergyStorage,
-    ElementalistRuneOfSuperiorFireMagic,
-    ElementalistRuneOfSuperiorAirMagic,
-    ElementalistRuneOfSuperiorEarthMagic,
-    ElementalistRuneOfSuperiorWaterMagic,
-    
-    UpgradeMinorRuneElementalist,
-    UpgradeMajorRuneElementalist,
-    UpgradeSuperiorRuneElementalist,
-    AppliesToMinorRuneElementalist,
-    AppliesToMajorRuneElementalist,
-    AppliesToSuperiorRuneElementalist,
-    
-    # Assassin
-    AssassinRuneOfMinorCriticalStrikes,
-    AssassinRuneOfMinorDaggerMastery,
-    AssassinRuneOfMinorDeadlyArts,
-    AssassinRuneOfMinorShadowArts,
-    AssassinRuneOfMajorCriticalStrikes,
-    AssassinRuneOfMajorDaggerMastery,
-    AssassinRuneOfMajorDeadlyArts,
-    AssassinRuneOfMajorShadowArts,
-    AssassinRuneOfSuperiorCriticalStrikes,
-    AssassinRuneOfSuperiorDaggerMastery,
-    AssassinRuneOfSuperiorDeadlyArts,
-    AssassinRuneOfSuperiorShadowArts,
-    
-    UpgradeMinorRuneAssassin,
-    UpgradeMajorRuneAssassin,
-    UpgradeSuperiorRuneAssassin,
-    AppliesToMinorRuneAssassin,
-    AppliesToMajorRuneAssassin,
-    AppliesToSuperiorRuneAssassin,
-    
-    # Ritualist
-    RitualistRuneOfMinorChannelingMagic,
-    RitualistRuneOfMinorRestorationMagic,
-    RitualistRuneOfMinorCommuning,
-    RitualistRuneOfMinorSpawningPower,
-    RitualistRuneOfMajorChannelingMagic,
-    RitualistRuneOfMajorRestorationMagic,
-    RitualistRuneOfMajorCommuning,
-    RitualistRuneOfMajorSpawningPower,
-    RitualistRuneOfSuperiorChannelingMagic,
-    RitualistRuneOfSuperiorRestorationMagic,
-    RitualistRuneOfSuperiorCommuning,
-    RitualistRuneOfSuperiorSpawningPower,
-    
-    UpgradeMinorRuneRitualist,
-    UpgradeMajorRuneRitualist,
-    UpgradeSuperiorRuneRitualist,
-    AppliesToMinorRuneRitualist,
-    AppliesToMajorRuneRitualist,
-    AppliesToSuperiorRuneRitualist,
-    
-    # Dervish
-    DervishRuneOfMinorMysticism,
-    DervishRuneOfMinorEarthPrayers,
-    DervishRuneOfMinorScytheMastery,
-    DervishRuneOfMinorWindPrayers,
-    DervishRuneOfMajorMysticism,
-    DervishRuneOfMajorEarthPrayers,
-    DervishRuneOfMajorScytheMastery,
-    DervishRuneOfMajorWindPrayers,
-    DervishRuneOfSuperiorMysticism,
-    DervishRuneOfSuperiorEarthPrayers,
-    DervishRuneOfSuperiorScytheMastery,
-    DervishRuneOfSuperiorWindPrayers,
-    
-    UpgradeMinorRuneDervish,
-    UpgradeMajorRuneDervish,
-    UpgradeSuperiorRuneDervish,
-    AppliesToMinorRuneDervish,
-    AppliesToMajorRuneDervish,
-    AppliesToSuperiorRuneDervish,
-    
-    # Paragon    
-    ParagonRuneOfMinorLeadership,
-    ParagonRuneOfMinorMotivation,
-    ParagonRuneOfMinorCommand,
-    ParagonRuneOfMinorSpearMastery,
-    ParagonRuneOfMajorLeadership,
-    ParagonRuneOfMajorMotivation,
-    ParagonRuneOfMajorCommand,
-    ParagonRuneOfMajorSpearMastery,
-    ParagonRuneOfSuperiorLeadership,
-    ParagonRuneOfSuperiorMotivation,
-    ParagonRuneOfSuperiorCommand,
-    ParagonRuneOfSuperiorSpearMastery,   
-    
-    UpgradeMinorRuneParagon,
-    UpgradeMajorRuneParagon,
-    UpgradeSuperiorRuneParagon,
-    AppliesToMinorRuneParagon,
-    AppliesToMajorRuneParagon,
-    AppliesToSuperiorRuneParagon, 
+    cls
+    for cls in _get_concrete_upgrade_types(
+        Upgrade,
+        excluded_types=(
+            Inherent,
+            Inscription,
+            OffhandInscription,
+            WeaponInscription,
+            MartialWeaponInscription,
+            OffhandOrShieldInscription,
+            ReduceConditionDurationInscription,
+            ArmorVsDamageTypeInscription,
+            EquippableItemInscription,
+            SpellcastingWeaponInscription,
+        ),
+        class_filter=lambda cls: not issubclass(cls, Inherent),
+    )
 ]
 
-_INHERENT_UPGRADES: list[type[Inherent]] = [
-    cls
-    for cls in globals().values()
-    if isinstance(cls, type)
-    and issubclass(cls, Inherent)
-    and cls is not Inherent
-    and cls.__module__ == __name__
-]
+_INHERENT_UPGRADES: list[type[Upgrade]] = _get_concrete_upgrade_types(
+    Inherent,
+    excluded_types=(
+        ArmorVsSpeciesUpgrade,
+        AttributePlusOneUpgrade,
+        HalvesCastingTimeAttributeUpgrade,
+        HalvesRechargeTimeAttributeUpgrade,
+    ),
+)

--- a/Py4GWCoreLib/item_mods_src/upgrades.py
+++ b/Py4GWCoreLib/item_mods_src/upgrades.py
@@ -2232,7 +2232,7 @@ class OfSlayingUpgrade(WeaponSuffix):
     damage_increase: int = 20
 
     def create_encoded_description(self) -> GWStringEncoded:
-        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_percent(self.get_text_color(), bytes([*GWEncoded.DAMAGE_TEXT, 0x1, 0x0]), self.damage_increase, f"Damage +{self.damage_increase}%"), GWEncoded._dull_parenthesized(bytes([*GWEncoded.VS_STR1, *GWEncoded.SLAYING_BANE.get(self.species, bytes())]), f"(vs. {self.species.name})"), f"(vs. {self.species.name})")
+        return GWEncoded._append_line_with_fallback(GWEncoded._bonus_plus_percent(self.get_text_color(), bytes([*GWEncoded.DAMAGE_TEXT, 0x1, 0x0]), self.damage_increase, f"Damage +{self.damage_increase}%"), GWEncoded._dull_parenthesized(bytes([*GWEncoded.VS_STR1, *GWEncoded.SPECIES.get(self.species, bytes())]), f"(vs. {self.species.name})"), f"(vs. {self.species.name})")
 
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + bytes([0xB, 0x1]) + GWEncoded.SLAYING_SUFFIXES.get(self.species, bytes()) + bytes([0x1, 0x0, 0x1, 0x0, 0x0, 0x0]), 
@@ -5616,13 +5616,12 @@ class ArmorVsSpeciesUpgrade(Inherent):
     species: ItemBaneSpecies | None = None
     target_item_type = ItemType.Weapon
 
-    #TODO: implement proper encoded description once we have the correct bytes for the species
     def create_encoded_description(self) -> GWStringEncoded:
         if self.species is None:
-            return GWStringEncoded(bytes(), f"Armor +{self.armor} ({_humanize_identifier(self.__class__.__name__)})")
+            return GWStringEncoded(bytes(), f"Armor +{self.armor} vs. ({_humanize_identifier(self.__class__.__name__)})")
         
-        species = self.species.name if self.species != ItemBaneSpecies.Unknown else f"Unknown species ({self.species.value})"
-        return GWStringEncoded(bytes(), f"Armor +{self.armor} (vs. {species}) [{_humanize_identifier(self.__class__.__name__)}]")
+        encoed_bytes = bytes([*self.get_text_color(), 0x84, 0xA, 0xA, 0x1, 0x44, 0xA, 0x1, 0x0, 0x1, 0x1, self.armor, 0x1, *GWEncoded.ITEM_DULL, 0xA8, 0xA, 0xA, 0x1, 0xAF, 0xA, 0xA, 0x1, *GWEncoded.SPECIES.get(self.species, bytes()), 0x1, 0x0, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 0x2, 0x0])
+        return GWStringEncoded(encoed_bytes, f"Armor +{self.armor} vs. ({_humanize_identifier(self.__class__.__name__)})")
 
 @dataclass(eq=False)
 class ArmorVsUndeadUpgrade(ArmorVsSpeciesUpgrade):

--- a/Py4GWCoreLib/native_src/internals/encoded_strings.py
+++ b/Py4GWCoreLib/native_src/internals/encoded_strings.py
@@ -238,7 +238,7 @@ class GWEncoded():
         # ItemBaneSpecies.Snakes :  bytes([0x63, 0xA]),
     }
     
-    SLAYING_BANE: dict[ItemBaneSpecies, bytes] = {
+    SPECIES: dict[ItemBaneSpecies, bytes] = {
         ItemBaneSpecies.Undead :    bytes([0xF7, 0x8]),
         ItemBaneSpecies.Charr :     bytes([0xEC, 0x8]),
         ItemBaneSpecies.Trolls :    bytes([0xF6, 0x8]),

--- a/Py4GWCoreLib/native_src/internals/encoded_strings.py
+++ b/Py4GWCoreLib/native_src/internals/encoded_strings.py
@@ -1,8 +1,8 @@
-from enum import Enum
 import re
+import struct
 from typing import Optional
 from Py4GWCoreLib.enums_src.GameData_enums import Ailment, Attribute, DamageType, Profession, Reduced_Ailment
-from Py4GWCoreLib.enums_src.Item_enums import ItemType, Rarity
+from Py4GWCoreLib.enums_src.Item_enums import ItemType
 from Py4GWCoreLib.native_src.internals import string_table
 from Py4GWCoreLib.item_mods_src.types import ItemBaneSpecies
 
@@ -22,8 +22,31 @@ class GWStringEncoded:
         self.__plain = ""
         self.__bonuses_only = ""
         self.__full = ""
+        self.__singular = ""
 
     def decode(self) -> str:
+        decoded = string_table.decode(self.encoded)
+        if self.placeholder_bytes:
+            decoded = decoded.replace(string_table.decode(self.placeholder_bytes), "").strip()
+            
+        return decoded if decoded else ""
+    
+    def decode_with_amount(self, amount: int) -> str:
+        if amount < 1:
+            raise ValueError("Encoded string amounts must be non-negative.")
+
+        encoded = bytes([
+            *GWEncoded.NUM1_STR1,
+            0x1, 0x1,
+            *GWEncoded._encode_string_table_number(amount),
+            0xA, 0x1,
+            *self.encoded,
+            0x1, 0x0,
+        ])
+        decoded = string_table.decode_plain(encoded)
+        return decoded if decoded else ""
+    
+    def get_decoded(self) -> str:
         decoded = string_table.decode(self.encoded)
         if self.placeholder_bytes:
             decoded = decoded.replace(string_table.decode(self.placeholder_bytes), "").strip()
@@ -49,73 +72,106 @@ class GWStringEncoded:
     @property
     def plain(self) -> str:
         if not self.__plain:
-            self.__plain = self.remove_placeholder(self.COLOR_TAG_RE.sub(r"\1", self.decode()))
-                            
+            decoded = self.decode()
+            if not decoded:
+                return self.fallback
+            
+            plain = self.remove_placeholder(self.COLOR_TAG_RE.sub(r"\1", decoded))
+            self.__plain = plain
+        
         return self.__plain
 
     @property
     def bonuses_only(self) -> str:
         if not self.__bonuses_only:
-            lines = self.decode().splitlines()
-            bonus_lines = [line for line in lines if line.startswith(self.STAT_TAGS)]
-            self.__bonuses_only = self.remove_placeholder(self.COLOR_TAG_RE.sub(r"\1", "\n".join(bonus_lines)))
-                
+            decoded = self.decode()
+            if not decoded:
+                return self.fallback
+            
+            lines = decoded.splitlines()
+            bonus_lines = [line for line in lines if line.startswith(self.STAT_TAGS)]            
+            bonuses_only = self.remove_placeholder(self.COLOR_TAG_RE.sub(r"\1", "\n".join(bonus_lines)))
+            self.__bonuses_only = bonuses_only
+
         return self.__bonuses_only
 
     @property
     def full(self) -> str:
         if not self.__full:
-            self.__full = self.remove_placeholder(self.decode())
-                            
+            decoded = self.decode()
+            if not decoded:
+                return self.fallback
+            
+            full = self.remove_placeholder(decoded)
+            self.__full = full
+
         return self.__full
+    
+    @property
+    def singular(self) -> str:
+        if not self.__singular:
+            decoded = self.decode()
+            
+            if not decoded:
+                return self.fallback
+            
+            if '[s]' in decoded or '[pl:' in decoded:
+                decoded = self.decode_with_amount(1)
+            
+            self.__singular = self.remove_placeholder(decoded)
+            
+        return self.__singular
+    
+    def with_amount(self, amount: int = 1) -> str:
+        return self.decode_with_amount(amount) or f"{amount} {self.plain}"
 
 
 
 class GWEncoded():
     UNKNOWNN = bytes([0x86, 0x21, 0x0, 0x0]) # "Unknown"
     ATTRIBUTE_NAMES = {
-        Attribute.FastCasting: bytes([0x1E, 0x9]),
-        Attribute.IllusionMagic: bytes([0x20, 0x9]),
-        Attribute.DominationMagic: bytes([0x22, 0x9]),
-        Attribute.InspirationMagic: bytes([0x24, 0x9]),
-        Attribute.BloodMagic: bytes([0x26, 0x9]),
-        Attribute.DeathMagic: bytes([0x2A, 0x9]),
-        Attribute.SoulReaping: bytes([0x2C, 0x9]),
-        Attribute.Curses: bytes([0x28, 0x9]),    
-        Attribute.AirMagic: bytes([0x2E, 0x9]),
-        Attribute.EarthMagic: bytes([0x30, 0x9]),
-        Attribute.FireMagic: bytes([0x34, 0x9]),
-        Attribute.WaterMagic: bytes([0x36, 0x9]),
-        Attribute.EnergyStorage: bytes([0x32, 0x9]),
-        Attribute.HealingPrayers: bytes([0x3A, 0x9]),
-        Attribute.SmitingPrayers: bytes([0x3E, 0x9]),
-        Attribute.ProtectionPrayers: bytes([0x3C, 0x9]),
-        Attribute.DivineFavor: bytes([0x38, 0x9]),
-        Attribute.Strength: bytes([0x40, 0x9]),    
-        Attribute.AxeMastery: bytes([0x42, 0x9]),
-        Attribute.HammerMastery: bytes([0x44, 0x9]),
-        Attribute.Swordsmanship: bytes([0x46, 0x9]),
-        Attribute.Tactics: bytes([0x48, 0x9]),    
-        Attribute.BeastMastery: bytes([0x50, 0x9]),
-        Attribute.Expertise: bytes([0x52, 0x9]),
-        Attribute.WildernessSurvival: bytes([0x54, 0x9]),
-        Attribute.Marksmanship: bytes([0x56, 0x9]),
-        Attribute.DaggerMastery: bytes([0x5A, 0x9]),
-        Attribute.DeadlyArts: bytes([0x5C, 0x9]),
-        Attribute.ShadowArts: bytes([0x5E, 0x9]),
-        Attribute.Communing: bytes([0x60, 0x9]),
-        Attribute.RestorationMagic: bytes([0x64, 0x9]),    
-        Attribute.ChannelingMagic: bytes([0x66, 0x9]),
-        Attribute.CriticalStrikes: bytes([0x58, 0x9]),
-        Attribute.SpawningPower: bytes([0x62, 0x9]),
-        Attribute.SpearMastery: bytes([0x1, 0x81, 0x20, 0x11]),
-        Attribute.Command: bytes([0x1, 0x81, 0xD5, 0x6]),
-        Attribute.Motivation: bytes([0x1, 0x81, 0x1A, 0x12]),
-        Attribute.Leadership: bytes([0x1, 0x81, 0x33, 0x12]),
-        Attribute.ScytheMastery: bytes([0x1, 0x81, 0x22, 0x11]),
-        Attribute.WindPrayers: bytes([0x1, 0x81, 0x35, 0x12]),
-        Attribute.EarthPrayers: bytes([0x1, 0x81, 0x37, 0x12]),
-        Attribute.Mysticism: bytes([0x1, 0x81, 0x39, 0x12]),
+        Attribute.FastCasting:          bytes([0x1E, 0x9]),
+        Attribute.IllusionMagic:        bytes([0x20, 0x9]),
+        Attribute.DominationMagic:      bytes([0x22, 0x9]),
+        Attribute.InspirationMagic:     bytes([0x24, 0x9]),
+        Attribute.BloodMagic:           bytes([0x26, 0x9]),
+        Attribute.DeathMagic:           bytes([0x2A, 0x9]),
+        Attribute.SoulReaping:          bytes([0x2C, 0x9]),
+        Attribute.Curses:               bytes([0x28, 0x9]),    
+        Attribute.AirMagic:             bytes([0x2E, 0x9]),
+        Attribute.EarthMagic:           bytes([0x30, 0x9]),
+        Attribute.FireMagic:            bytes([0x34, 0x9]),
+        Attribute.WaterMagic:           bytes([0x36, 0x9]),
+        Attribute.EnergyStorage:        bytes([0x32, 0x9]),
+        Attribute.HealingPrayers:       bytes([0x3A, 0x9]),
+        Attribute.SmitingPrayers:       bytes([0x3E, 0x9]),
+        Attribute.ProtectionPrayers:    bytes([0x3C, 0x9]),
+        Attribute.DivineFavor:          bytes([0x38, 0x9]),
+        Attribute.Strength:             bytes([0x40, 0x9]),    
+        Attribute.AxeMastery:           bytes([0x42, 0x9]),
+        Attribute.HammerMastery:        bytes([0x44, 0x9]),
+        Attribute.Swordsmanship:        bytes([0x46, 0x9]),
+        Attribute.Tactics:              bytes([0x48, 0x9]),    
+        Attribute.BeastMastery:         bytes([0x50, 0x9]),
+        Attribute.Expertise:            bytes([0x52, 0x9]),
+        Attribute.WildernessSurvival:   bytes([0x54, 0x9]),
+        Attribute.Marksmanship:         bytes([0x56, 0x9]),
+        Attribute.DaggerMastery:        bytes([0x5A, 0x9]),
+        Attribute.DeadlyArts:           bytes([0x5C, 0x9]),
+        Attribute.ShadowArts:           bytes([0x5E, 0x9]),
+        Attribute.Communing:            bytes([0x60, 0x9]),
+        Attribute.RestorationMagic:     bytes([0x64, 0x9]),    
+        Attribute.ChannelingMagic:      bytes([0x66, 0x9]),
+        Attribute.CriticalStrikes:      bytes([0x58, 0x9]),
+        Attribute.SpawningPower:        bytes([0x62, 0x9]),
+        Attribute.SpearMastery:         bytes([0x1, 0x81, 0x20, 0x11]),
+        Attribute.Command:              bytes([0x1, 0x81, 0xD5, 0x6]),
+        Attribute.Motivation:           bytes([0x1, 0x81, 0x1A, 0x12]),
+        Attribute.Leadership:           bytes([0x1, 0x81, 0x33, 0x12]),
+        Attribute.ScytheMastery:        bytes([0x1, 0x81, 0x22, 0x11]),
+        Attribute.WindPrayers:          bytes([0x1, 0x81, 0x35, 0x12]),
+        Attribute.EarthPrayers:         bytes([0x1, 0x81, 0x37, 0x12]),
+        Attribute.Mysticism:            bytes([0x1, 0x81, 0x39, 0x12]),
     }
 
     STR1_STR2 = bytes([0x30, 0xA, 0xA, 0x1]) # %str1% %str2%
@@ -127,129 +183,132 @@ class GWEncoded():
     STAFF_WRAPPING_OF_STR2 = bytes([0x33, 0xA, 0xA, 0x1, 0xBF, 0x22, 0x1, 0x0, 0xB, 0x1]) # Staff Wrapping of %str2%
     PARENTHESIS_STR1 = bytes([0xA8, 0xA, 0xA, 0x1]) # (%str1%)
     VS_STR1 = bytes([0xAF, 0xA, 0xA, 0x1])
+    NUM1_STR1 = bytes([0x35, 0xA])
 
     STR1_PLUS_NUM1 = bytes([0x84, 0xA, 0xA, 0x1])
 
-    PLACEHOLDER_TO_REMOVE = bytes([0x9, 0x1, 0x0, 0x0])
+    PLACEHOLDER_TO_REMOVE = bytes([0xA5, 0x1, 0x1, 0x0])
     
     NON_STACKING = bytes([0xA8, 0xA, 0xA, 0x1, 0xB2, 0xA, 0x1, 0x0, 0x1, 0x0])
     HEALTH_MINUS_75 = bytes([0x7E, 0xA, 0xA, 0x1, 0x52, 0xA, 0x1, 0x0, 0x1, 0x1, 0x4B, 0x1, 0x1, 0x0]) # 0x4B = 75 in little endian, 0x1 = minus, 0x0 = health
     HEALTH_MINUS_NUM = bytes([0x7E, 0xA, 0xA, 0x1, 0x52, 0xA, 0x1, 0x0, 0x1, 0x1]) # 0x4B = 75 in little endian, 0x1 = minus, 0x0 = health
-
+    NUM1_GOLD = bytes([0xC2, 0xA])
+    NUM1_PLATINUM = bytes([0xC3, 0xA])
+    
     WEAPON_PREFIXES: dict[ItemType, bytes] = {
-        ItemType.Axe : bytes([*STR1_STR2, 0xB0, 0x22, 0x1, 0x0]), #Axe Haft
-        ItemType.Bow : bytes([*STR1_STR2, 0xB1, 0x22, 0x1, 0x0]), #Bow String
-        ItemType.Daggers : bytes([*STR1_STR2, 0xBE, 0x55, 0x1, 0x0]), #Dagger Tang
+        ItemType.Axe :      bytes([*STR1_STR2, 0xB0, 0x22, 0x1, 0x0, 0xB, 0x1]), #Axe Haft
+        ItemType.Bow :      bytes([*STR1_STR2, 0xB1, 0x22, 0x1, 0x0, 0xB, 0x1]), #Bow String
+        ItemType.Daggers :  bytes([*STR1_STR2, 0xBE, 0x55, 0x1, 0x0, 0xB, 0x1]), #Dagger Tang
         # ItemType.Offhand does not have a prefix mod, so no name format is needed
-        ItemType.Hammer : bytes([*STR1_STR2, 0xB2, 0x22, 0x1, 0x0]), #Hammer Haft
-        ItemType.Scythe : bytes([*STR1_STR2, 0x1, 0x81, 0x73, 0x1C]), #Scythe Snathe
+        ItemType.Hammer :   bytes([*STR1_STR2, 0xB2, 0x22, 0x1, 0x0, 0xB, 0x1]), #Hammer Haft
+        ItemType.Scythe :   bytes([*STR1_STR2, 0x1, 0x81, 0x6F, 0x1C, 0x1, 0x0, 0xB, 0x1]), #Scythe Snathe
         # ItemType.Shield does not have a prefix mod, so no name format is needed
-        ItemType.Spear : bytes([*STR1_STR2, 0x1, 0x81, 0x70, 0x1C, 0x1, 0x0]), #Spearhead
-        ItemType.Staff : bytes([*STR1_STR2, 0xB3, 0x22, 0x1, 0x0]), #Staff Head
-        ItemType.Sword : bytes([*STR1_STR2, 0xB4, 0x22, 0x1, 0x0]), #Sword Hilt
+        ItemType.Spear :    bytes([*STR1_STR2, 0x1, 0x81, 0x70, 0x1C, 0x1, 0x0, 0xB, 0x1]), #Spearhead
+        ItemType.Staff :    bytes([*STR1_STR2, 0xB3, 0x22, 0x1, 0x0, 0xB, 0x1]), #Staff Head
+        ItemType.Sword :    bytes([*STR1_STR2, 0xB4, 0x22, 0x1, 0x0, 0xB, 0x1]), #Sword Hilt
         # ItemType.Wand does not have a prefix mod, so no name format is needed    
     }
 
     WEAPON_SUFFIXES: dict[ItemType, bytes] = {
-        ItemType.Axe : bytes([*STR1_OF_STR2, 0xB0, 0x22, 0x1, 0x0]), #Axe Grip
-        ItemType.Bow : bytes([*STR1_OF_STR2, 0xBD, 0x22, 0x1, 0x0]), #Bow Grip
-        ItemType.Daggers : bytes([*STR1_OF_STR2, 0xC1, 0x55, 0x1, 0x0]), #Dagger Handle
-        ItemType.Offhand : bytes([*STR1_OF_STR2, 0x1, 0x81, 0xEB, 0x1C, 0x1, 0x0]), #Focus Core
-        ItemType.Hammer : bytes([*STR1_OF_STR2, 0xBE, 0x22, 0x1, 0x0]), #Hammer Grip
-        ItemType.Scythe : bytes([*STR1_OF_STR2, 0x1, 0x81, 0x73, 0x1C]), #Scythe Grip
-        ItemType.Shield : bytes([*STR1_OF_STR2, 0x1, 0x81, 0xED, 0x1C, 0x1, 0x0]), #Shield Handle
-        ItemType.Spear : bytes([*STR1_OF_STR2, 0x1, 0x81, 0x74, 0x1C, 0x1, 0x0]), #Spear Grip
-        ItemType.Staff : bytes([*STR1_OF_STR2, 0xBF, 0x22, 0x1, 0x0]), #Staff Wrapping
-        ItemType.Sword : bytes([*STR1_OF_STR2, 0xC0, 0x22, 0x1, 0x0]), #Sword Pommel
-        ItemType.Wand : bytes([*STR1_OF_STR2, 0x1, 0x81, 0xEC, 0x1C, 0x1, 0x0]), #Wand Wrapping
+        ItemType.Axe :      bytes([*STR1_OF_STR2, 0xB0, 0x22, 0x1, 0x0]), #Axe Grip
+        ItemType.Bow :      bytes([*STR1_OF_STR2, 0xBD, 0x22, 0x1, 0x0]), #Bow Grip
+        ItemType.Daggers :  bytes([*STR1_OF_STR2, 0xC1, 0x55, 0x1, 0x0]), #Dagger Handle
+        ItemType.Offhand :  bytes([*STR1_OF_STR2, 0x1, 0x81, 0xEB, 0x1C, 0x1, 0x0]), #Focus Core
+        ItemType.Hammer :   bytes([*STR1_OF_STR2, 0xBE, 0x22, 0x1, 0x0]), #Hammer Grip
+        ItemType.Scythe :   bytes([*STR1_OF_STR2, 0x1, 0x81, 0x73, 0x1C]), #Scythe Grip
+        ItemType.Shield :   bytes([*STR1_OF_STR2, 0x1, 0x81, 0xED, 0x1C, 0x1, 0x0]), #Shield Handle
+        ItemType.Spear :    bytes([*STR1_OF_STR2, 0x1, 0x81, 0x74, 0x1C, 0x1, 0x0]), #Spear Grip
+        ItemType.Staff :    bytes([*STR1_OF_STR2, 0xBF, 0x22, 0x1, 0x0]), #Staff Wrapping
+        ItemType.Sword :    bytes([*STR1_OF_STR2, 0xC0, 0x22, 0x1, 0x0]), #Sword Pommel
+        ItemType.Wand :     bytes([*STR1_OF_STR2, 0x1, 0x81, 0xEC, 0x1C, 0x1, 0x0]), #Wand Wrapping
     }
     
     SLAYING_SUFFIXES: dict[ItemBaneSpecies, bytes] = {
-        ItemBaneSpecies.Undead : bytes([0xB, 0x1, 0x68, 0xA, 0x1, 0x0]),
-        ItemBaneSpecies.Charr : bytes([0xB, 0x1, 0x5D, 0xA, 0x1, 0x0]),
-        ItemBaneSpecies.Trolls : bytes([0xB, 0x1, 0x67, 0xA, 0x1, 0x0]),
-        ItemBaneSpecies.Plants : bytes([0xB, 0x1, 0x64, 0xA, 0x1, 0x0]),
-        ItemBaneSpecies.Skeletons : bytes([0xB, 0x1, 0x65, 0xA, 0x1, 0x0]),
-        ItemBaneSpecies.Giants : bytes([0xB, 0x1, 0x62, 0xA, 0x1, 0x0]),
-        ItemBaneSpecies.Dwarves : bytes([0xB, 0x1, 0x60, 0xA, 0x1, 0x0]),
-        ItemBaneSpecies.Tengus : bytes([0xB, 0x1, 0x66, 0xA, 0x1, 0x0]),
-        ItemBaneSpecies.Demons : bytes([0xB, 0x1, 0x5E, 0xA, 0x1, 0x0]),
-        ItemBaneSpecies.Dragons : bytes([0xB, 0x1, 0x5F, 0xA, 0x1, 0x0]),
-        ItemBaneSpecies.Ogres : bytes([0xB, 0x1, 0x61, 0xA, 0x1, 0x0]),
-        # ItemBaneSpecies.Snakes : bytes([0xB, 0x1, 0x63, 0xA, 0x1, 0x0]),
+        ItemBaneSpecies.Undead :    bytes([0x68, 0xA]),
+        ItemBaneSpecies.Charr :     bytes([0x5D, 0xA]),
+        ItemBaneSpecies.Trolls :    bytes([0x67, 0xA]),
+        ItemBaneSpecies.Plants :    bytes([0x64, 0xA]),
+        ItemBaneSpecies.Skeletons : bytes([0x65, 0xA]),
+        ItemBaneSpecies.Giants :    bytes([0x62, 0xA]),
+        ItemBaneSpecies.Dwarves :   bytes([0x60, 0xA]),
+        ItemBaneSpecies.Tengus :    bytes([0x66, 0xA]),
+        ItemBaneSpecies.Demons :    bytes([0x5E, 0xA]),
+        ItemBaneSpecies.Dragons :   bytes([0x5F, 0xA]),
+        ItemBaneSpecies.Ogres :     bytes([0x61, 0xA]),
+        # ItemBaneSpecies.Snakes :  bytes([0x63, 0xA]),
     }
     
     SLAYING_BANE: dict[ItemBaneSpecies, bytes] = {
-        ItemBaneSpecies.Undead : bytes([0xF7, 0x8]),
-        ItemBaneSpecies.Charr : bytes([0xEC, 0x8]),
-        ItemBaneSpecies.Trolls : bytes([0xF6, 0x8]),
-        ItemBaneSpecies.Plants : bytes([0xF3, 0x8]),
+        ItemBaneSpecies.Undead :    bytes([0xF7, 0x8]),
+        ItemBaneSpecies.Charr :     bytes([0xEC, 0x8]),
+        ItemBaneSpecies.Trolls :    bytes([0xF6, 0x8]),
+        ItemBaneSpecies.Plants :    bytes([0xF3, 0x8]),
         ItemBaneSpecies.Skeletons : bytes([0xF4, 0x8]),
-        ItemBaneSpecies.Giants : bytes([0xF1, 0x8]),
-        ItemBaneSpecies.Dwarves : bytes([0xEF, 0x8]),
-        ItemBaneSpecies.Tengus : bytes([0xF5, 0x8]),
-        ItemBaneSpecies.Demons : bytes([0xED, 0x8]),
-        ItemBaneSpecies.Dragons : bytes([0xEE, 0x8]),
-        ItemBaneSpecies.Ogres : bytes([0xF0, 0x8]),
+        ItemBaneSpecies.Giants :    bytes([0xF1, 0x8]),
+        ItemBaneSpecies.Dwarves :   bytes([0xEF, 0x8]),
+        ItemBaneSpecies.Tengus :    bytes([0xF5, 0x8]),
+        ItemBaneSpecies.Demons :    bytes([0xED, 0x8]),
+        ItemBaneSpecies.Dragons :   bytes([0xEE, 0x8]),
+        ItemBaneSpecies.Ogres :     bytes([0xF0, 0x8]),
         # ItemBaneSpecies.Snakes : bytes([0xF2, 0x8]),
     }
     
     PROFESSION : dict[Profession, bytes] = {
-        Profession.Warrior: bytes([0xF9, 0x8]),
-        Profession.Ranger: bytes([0xFA, 0x8]),
-        Profession.Monk: bytes([0xFB, 0x8]),
-        Profession.Necromancer: bytes([0xFC, 0x8]),
-        Profession.Mesmer: bytes([0xFD, 0x8]),
-        Profession.Elementalist: bytes([0xFE, 0x8]),
-        Profession.Assassin: bytes([0xFF, 0x8]),
-        Profession.Ritualist: bytes([0x00, 0x09]),
-        Profession.Paragon: bytes([0x3C, 0x7C]),
-        Profession.Dervish: bytes([0x3D, 0x7C]),
+        Profession.Warrior:         bytes([0xF9, 0x8]),
+        Profession.Ranger:          bytes([0xFA, 0x8]),
+        Profession.Monk:            bytes([0xFB, 0x8]),
+        Profession.Necromancer:     bytes([0xFC, 0x8]),
+        Profession.Mesmer:          bytes([0xFD, 0x8]),
+        Profession.Elementalist:    bytes([0xFE, 0x8]),
+        Profession.Assassin:        bytes([0xFF, 0x8]),
+        Profession.Ritualist:       bytes([0x00, 0x09]),
+        Profession.Paragon:         bytes([0x3C, 0x7C]),
+        Profession.Dervish:         bytes([0x3D, 0x7C]),
     }
     
     PROFESSION_SHORT : dict[Profession, bytes] = {
-        Profession.Warrior: bytes([0x2, 0x9]),
-        Profession.Ranger: bytes([0x3, 0x9]),
-        Profession.Monk: bytes([0x4, 0x9]),
-        Profession.Necromancer: bytes([0x5, 0x9]),
-        Profession.Mesmer: bytes([0x6, 0x9]),
-        Profession.Elementalist: bytes([0x7, 0x9]),
-        Profession.Assassin: bytes([0x8, 0x9]),
-        Profession.Ritualist: bytes([0x9, 0x9]),
-        Profession.Paragon: bytes([0x41, 0x7C]),
-        Profession.Dervish: bytes([0x42, 0x7C]),
+        Profession.Warrior:         bytes([0x2, 0x9]),
+        Profession.Ranger:          bytes([0x3, 0x9]),
+        Profession.Monk:            bytes([0x4, 0x9]),
+        Profession.Necromancer:     bytes([0x5, 0x9]),
+        Profession.Mesmer:          bytes([0x6, 0x9]),
+        Profession.Elementalist:    bytes([0x7, 0x9]),
+        Profession.Assassin:        bytes([0x8, 0x9]),
+        Profession.Ritualist:       bytes([0x9, 0x9]),
+        Profession.Paragon:         bytes([0x41, 0x7C]),
+        Profession.Dervish:         bytes([0x42, 0x7C]),
     }
     
     THE_PROFESSION : dict[Profession, bytes] = {
-        Profession.Assassin: bytes([0xB, 0x1, 0x2, 0x81, 0xB2, 0x38, 0x1, 0x0]),
-        Profession.Dervish: bytes([0xB, 0x1, 0x2, 0x81, 0xB5, 0x38, 0x1, 0x0]),
-        Profession.Elementalist: bytes([0xB, 0x1, 0x2, 0x81, 0xAF, 0x38, 0x1, 0x0]),
-        Profession.Mesmer: bytes([0xB, 0x1, 0x2, 0x81, 0xAC, 0x38, 0x1, 0x0]),
-        Profession.Monk: bytes([0xB, 0x1, 0x2, 0x81, 0xAE, 0x38, 0x1, 0x0]),
-        Profession.Necromancer: bytes([0xB, 0x1, 0x2, 0x81, 0xAD, 0x38, 0x1, 0x0]),
-        Profession.Paragon: bytes([0xB, 0x1, 0x2, 0x81, 0xB4, 0x38, 0x1, 0x0]),
-        Profession.Ranger: bytes([0xB, 0x1, 0x2, 0x81, 0xB1, 0x38, 0x1, 0x0]),
-        Profession.Ritualist: bytes([0xB, 0x1, 0x2, 0x81, 0xB3, 0x38, 0x1, 0x0]),
-        Profession.Warrior: bytes([0xB, 0x1, 0x2, 0x81, 0xB0, 0x38, 0x1, 0x0]),
+        Profession.Assassin:        bytes([0xB, 0x1, 0x2, 0x81, 0xB2, 0x38, 0x1, 0x0]),
+        Profession.Dervish:         bytes([0xB, 0x1, 0x2, 0x81, 0xB5, 0x38, 0x1, 0x0]),
+        Profession.Elementalist:    bytes([0xB, 0x1, 0x2, 0x81, 0xAF, 0x38, 0x1, 0x0]),
+        Profession.Mesmer:          bytes([0xB, 0x1, 0x2, 0x81, 0xAC, 0x38, 0x1, 0x0]),
+        Profession.Monk:            bytes([0xB, 0x1, 0x2, 0x81, 0xAE, 0x38, 0x1, 0x0]),
+        Profession.Necromancer:     bytes([0xB, 0x1, 0x2, 0x81, 0xAD, 0x38, 0x1, 0x0]),
+        Profession.Paragon:         bytes([0xB, 0x1, 0x2, 0x81, 0xB4, 0x38, 0x1, 0x0]),
+        Profession.Ranger:          bytes([0xB, 0x1, 0x2, 0x81, 0xB1, 0x38, 0x1, 0x0]),
+        Profession.Ritualist:       bytes([0xB, 0x1, 0x2, 0x81, 0xB3, 0x38, 0x1, 0x0]),
+        Profession.Warrior:         bytes([0xB, 0x1, 0x2, 0x81, 0xB0, 0x38, 0x1, 0x0]),
     }
             
     DAMAGE_TYPE_BYTES = {
-        DamageType.Blunt: bytes([0xDE, 0x8]),
-        DamageType.Piercing: bytes([0xDF, 0x8]),
-        DamageType.Slashing: bytes([0xE0, 0x8]),
-        DamageType.Cold: bytes([0xE1, 0x8]),
-        DamageType.Lightning: bytes([0xE3, 0x8]),
-        DamageType.Fire: bytes([0xE4, 0x8]),
-        DamageType.Chaos: bytes([0xE5, 0x8]),
-        DamageType.Dark: bytes([0xE6, 0x8]),
-        DamageType.Holy: bytes([0xE7, 0x8]),
-        DamageType.unknown_9: bytes([]),
-        DamageType.unknown_10: bytes([]),
-        DamageType.Earth: bytes([0xE2, 0x8]),
-        DamageType.unknown_12: bytes([]),
-        DamageType.unknown_13: bytes([]),
-        DamageType.unknown_14: bytes([]),
-        DamageType.unknown_15: bytes([]),
+        DamageType.Blunt:       bytes([0xDE, 0x8]),
+        DamageType.Piercing:    bytes([0xDF, 0x8]),
+        DamageType.Slashing:    bytes([0xE0, 0x8]),
+        DamageType.Cold:        bytes([0xE1, 0x8]),
+        DamageType.Lightning:   bytes([0xE3, 0x8]),
+        DamageType.Fire:        bytes([0xE4, 0x8]),
+        DamageType.Chaos:       bytes([0xE5, 0x8]),
+        DamageType.Dark:        bytes([0xE6, 0x8]),
+        DamageType.Holy:        bytes([0xE7, 0x8]),
+        DamageType.unknown_9:   bytes([]),
+        DamageType.unknown_10:  bytes([]),
+        DamageType.Earth:       bytes([0xE2, 0x8]),
+        DamageType.unknown_12:  bytes([]),
+        DamageType.unknown_13:  bytes([]),
+        DamageType.unknown_14:  bytes([]),
+        DamageType.unknown_15:  bytes([]),
     }
                               
     ITEM_BASIC = bytes([0x2, 0x0, 0x3B, 0xA, 0xA, 0x1])
@@ -314,38 +373,39 @@ class GWEncoded():
     REDUCES_DISEASE_DURATION_BYTES = bytes([0xA7, 0xA, 0xA, 0x1, 0x92, 0x62, 0x1, 0x0, 0x1, 0x0])
 
     VS_DAMAGE_BYTES = {
-        DamageType.Blunt: bytes([0xAC, 0xA, 0xA, 0x1, 0xDE, 0x8, 0x1, 0x0, 0x1, 0x0]),
-        DamageType.Cold: bytes([0xAC, 0xA, 0xA, 0x1, 0xE1, 0x8, 0x1, 0x0, 0x1, 0x0]),
-        DamageType.Earth: bytes([0xAC, 0xA, 0xA, 0x1, 0xE2, 0x8, 0x1, 0x0, 0x1, 0x0]),
-        DamageType.Fire: bytes([0xAC, 0xA, 0xA, 0x1, 0xE4, 0x8, 0x1, 0x0, 0x1, 0x0]),
-        DamageType.Lightning: bytes([0xAC, 0xA, 0xA, 0x1, 0xE3, 0x8, 0x1, 0x0, 0x1, 0x0]),
-        DamageType.Piercing: bytes([0xAC, 0xA, 0xA, 0x1, 0xDF, 0x8, 0x1, 0x0, 0x1, 0x0]),
-        DamageType.Slashing: bytes([0xAC, 0xA, 0xA, 0x1, 0xE0, 0x8, 0x1, 0x0, 0x1, 0x0]),
+        DamageType.Blunt:       bytes([0xAC, 0xA, 0xA, 0x1, 0xDE, 0x8, 0x1, 0x0, 0x1, 0x0]),
+        DamageType.Cold:        bytes([0xAC, 0xA, 0xA, 0x1, 0xE1, 0x8, 0x1, 0x0, 0x1, 0x0]),
+        DamageType.Earth:       bytes([0xAC, 0xA, 0xA, 0x1, 0xE2, 0x8, 0x1, 0x0, 0x1, 0x0]),
+        DamageType.Fire:        bytes([0xAC, 0xA, 0xA, 0x1, 0xE4, 0x8, 0x1, 0x0, 0x1, 0x0]),
+        DamageType.Lightning:   bytes([0xAC, 0xA, 0xA, 0x1, 0xE3, 0x8, 0x1, 0x0, 0x1, 0x0]),
+        DamageType.Piercing:    bytes([0xAC, 0xA, 0xA, 0x1, 0xDF, 0x8, 0x1, 0x0, 0x1, 0x0]),
+        DamageType.Slashing:    bytes([0xAC, 0xA, 0xA, 0x1, 0xE0, 0x8, 0x1, 0x0, 0x1, 0x0]),
     }
 
     CONDITION_INCREASE_BYTES = {
-        Ailment.Crippled: bytes([0xA4, 0xA, 0xA, 0x1, 0x8E, 0x62, 0x1, 0x0, 0x1, 0x0]),
-        Ailment.Dazed: bytes([0xA4, 0xA, 0xA, 0x1, 0x96, 0x62, 0x1, 0x0, 0x1, 0x0]),
-        Ailment.Deep_Wound: bytes([0xA4, 0xA, 0xA, 0x1, 0x90, 0x62, 0x1, 0x0, 0x1, 0x0]),
-        Ailment.Weakness: bytes([0xA4, 0xA, 0xA, 0x1, 0x98, 0x62, 0x1, 0x0, 0x1, 0x0]),
+        Ailment.Crippled:       bytes([0xA4, 0xA, 0xA, 0x1, 0x8E, 0x62, 0x1, 0x0, 0x1, 0x0]),
+        Ailment.Dazed:          bytes([0xA4, 0xA, 0xA, 0x1, 0x96, 0x62, 0x1, 0x0, 0x1, 0x0]),
+        Ailment.Deep_Wound:     bytes([0xA4, 0xA, 0xA, 0x1, 0x90, 0x62, 0x1, 0x0, 0x1, 0x0]),
+        Ailment.Weakness:       bytes([0xA4, 0xA, 0xA, 0x1, 0x98, 0x62, 0x1, 0x0, 0x1, 0x0]),
     }
 
     REDUCED_CONDITION_BYTES = {
-        Reduced_Ailment.Bleeding: bytes([0xA7, 0xA, 0xA, 0x1, 0x88, 0x62, 0x1, 0x0, 0x1, 0x0]),
-        Reduced_Ailment.Blind: bytes([0xA7, 0xA, 0xA, 0x1, 0x8A, 0x62, 0x1, 0x0, 0x1, 0x0]),
-        Reduced_Ailment.Crippled: bytes([0xA7, 0xA, 0xA, 0x1, 0x8E, 0x62, 0x1, 0x0, 0x1, 0x0]),
-        Reduced_Ailment.Dazed: bytes([0xA7, 0xA, 0xA, 0x1, 0x96, 0x62, 0x1, 0x0, 0x1, 0x0]),
+        Reduced_Ailment.Bleeding:   bytes([0xA7, 0xA, 0xA, 0x1, 0x88, 0x62, 0x1, 0x0, 0x1, 0x0]),
+        Reduced_Ailment.Blind:      bytes([0xA7, 0xA, 0xA, 0x1, 0x8A, 0x62, 0x1, 0x0, 0x1, 0x0]),
+        Reduced_Ailment.Crippled:   bytes([0xA7, 0xA, 0xA, 0x1, 0x8E, 0x62, 0x1, 0x0, 0x1, 0x0]),
+        Reduced_Ailment.Dazed:      bytes([0xA7, 0xA, 0xA, 0x1, 0x96, 0x62, 0x1, 0x0, 0x1, 0x0]),
         Reduced_Ailment.Deep_Wound: bytes([0xA7, 0xA, 0xA, 0x1, 0x90, 0x62, 0x1, 0x0, 0x1, 0x0]),
-        Reduced_Ailment.Disease: bytes([0xA7, 0xA, 0xA, 0x1, 0x92, 0x62, 0x1, 0x0, 0x1, 0x0]),
-        Reduced_Ailment.Poison: bytes([0xA7, 0xA, 0xA, 0x1, 0x94, 0x62, 0x1, 0x0, 0x1, 0x0]),
-        Reduced_Ailment.Weakness: bytes([0xA7, 0xA, 0xA, 0x1, 0x98, 0x62, 0x1, 0x0, 0x1, 0x0]),
+        Reduced_Ailment.Disease:    bytes([0xA7, 0xA, 0xA, 0x1, 0x92, 0x62, 0x1, 0x0, 0x1, 0x0]),
+        Reduced_Ailment.Poison:     bytes([0xA7, 0xA, 0xA, 0x1, 0x94, 0x62, 0x1, 0x0, 0x1, 0x0]),
+        Reduced_Ailment.Weakness:   bytes([0xA7, 0xA, 0xA, 0x1, 0x98, 0x62, 0x1, 0x0, 0x1, 0x0]),
     }
 
+    REQUIRES_NUM1_STR1 = bytes([0xA9, 0xA, 0xA, 0x1]) # Requires %num1% %str1%
     DAMAGE_TEXT = bytes([0x4E, 0xA])
     DAMAGE_PLUS_PERCENT = bytes([*ITEM_BONUS, *PLUS_PERCENT_TEMPLATE, *DAMAGE_TEXT, 0x1, 0x0, 0x1, 0x1, ]) # Damage +X%
 
     ARMOR_TEXT = bytes([0x1, 0x81, 0xA4, 0x13])
-    GOLD_VALUE = bytes([0x8A, 0xA, 0xA, 0x1, 0x59, 0xA, 0x1, 0x0, 0xB, 0x1, 0xC2, 0xA, 0x1, 0x1])
+    GOLD_VALUE = bytes([0x8A, 0xA, 0xA, 0x1, 0x59, 0xA, 0x1, 0x0, 0xB, 0x1, *NUM1_GOLD, 0x1, 0x1])
     USE_TO_APPLY_TO_ITEM = bytes([0x97, 0xA, 0x1])
     UPGRADE_COMPONENT = bytes([0x96, 0xA,])
     ATTACHES_TO = bytes([0x1, 0x81, 0x1C, 0x14, 0xA, 0x1])
@@ -359,6 +419,54 @@ class GWEncoded():
                                             *ITEM_DULL, *ATTACHES_TO, *ARMOR_TEXT, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1,
                                             *ITEM_DULL, *GOLD_VALUE, gold_amount, 0x1, 0x1, 0x0, 0x1, 0x0, 0x2, 0x0, 0x2, 0x1, 
                                             *ITEM_DULL, *USE_TO_APPLY_TO_ITEM, 0x0, 0x0, 0x0])
+    
+    ItemsAtrribute = bytes([0x1, 0x81, 0x86, 0x5E])
+    #0xA9, 0xA, 0xA, 0x1, (0x1, 0x81, 0x22, 0x11), 0x1, 0x0, 0x1, 0x1, (0x9, 0x1)
+    
+    #0xA9, 0xA, 0xA, 0x1, (0x1, 0x81, 0x86, 0x5E)
+    @staticmethod
+    def _requires_attribute_level(attribute : Attribute = Attribute.None_, attribute_level: int = 0) -> bytes:        
+        return bytes([*GWEncoded.REQUIRES_NUM1_STR1, *GWEncoded.ATTRIBUTE_NAMES.get(attribute, GWEncoded.ItemsAtrribute), 0x1, 0x0, 0x1, 0x1, *GWEncoded._encode_string_table_number(attribute_level)])
+    
+    @staticmethod
+    #0xA9, 0xA, 0xA, 0x1, 0x1, 0x81, 0x86, 0x5E 0x1, 0x0, 0x1, 0x1,( 0x9, 0x1)
+    def _requires_items_attribute_level(attribute : Attribute = Attribute.None_, attribute_level: int = 0) -> bytes:        
+        return bytes([*GWEncoded.REQUIRES_NUM1_STR1, *GWEncoded.ATTRIBUTE_NAMES.get(attribute, GWEncoded.ItemsAtrribute), 0x1, 0x0, 0x1, 0x1, *GWEncoded._encode_string_table_number(attribute_level)])
+    
+    @staticmethod
+    def _encode_string_table_number(value: int) -> bytes:
+        if value < 0:
+            raise ValueError("String-table numeric arguments must be non-negative.")
+
+        if value == 0:
+            return b""
+
+        digits: list[int] = []
+        current = value
+        while current > 0:
+            current, remainder = divmod(current, string_table._RANGE)
+            digits.append(remainder + string_table._BASE)
+
+        digits.reverse()
+        for i in range(len(digits) - 1):
+            digits[i] |= string_table._MORE
+
+        return struct.pack(f"<{len(digits)}H", *digits)
+
+    @staticmethod
+    def _gold_amount_bytes(amount: int) -> bytes:
+        return bytes([*GWEncoded.NUM1_GOLD, 0x1, 0x1]) + GWEncoded._encode_string_table_number(amount) + bytes([0x1, 0x0])
+
+    @staticmethod
+    def _platinum_amount_bytes(amount: int) -> bytes:
+        return bytes([*GWEncoded.NUM1_PLATINUM, 0x1, 0x1]) + GWEncoded._encode_string_table_number(amount) + bytes([0x1, 0x0])
+    
+    @staticmethod
+    def _formatted_currency_amount_bytes(amount: int) -> tuple[bytes, bytes]:
+        platinum_amount = amount // 1000
+        gold_amount = amount % 1000
+    
+        return GWEncoded._platinum_amount_bytes(platinum_amount) if platinum_amount > 0 else b"", GWEncoded._gold_amount_bytes(gold_amount) if gold_amount > 0 else b""
     
     @staticmethod
     def _attribute_bytes(attribute: Attribute) -> bytes | None:

--- a/Py4GWCoreLib/routines_src/behaviourtrees_src/items.py
+++ b/Py4GWCoreLib/routines_src/behaviourtrees_src/items.py
@@ -875,7 +875,7 @@ class BTItems:
                 if remaining_quantity > 0:
                     return BehaviorTree.NodeState.FAILURE
 
-            GLOBAL_CACHE.Trading.Collector.ExghangeItem(
+            GLOBAL_CACHE.Trading.Collector.ExchangeItem(
                 offered_item_id,
                 cost,
                 trade_item_ids,

--- a/Widgets/Automation/Bots/Farmers/Trophies/War Supply/Confessors Orders Exchange.py
+++ b/Widgets/Automation/Bots/Farmers/Trophies/War Supply/Confessors Orders Exchange.py
@@ -79,7 +79,7 @@ def _exchange_orders():
         if not give_ids:
             break   # not enough orders remaining across all stacks
 
-        GLOBAL_CACHE.Trading.Collector.ExghangeItem(
+        GLOBAL_CACHE.Trading.Collector.ExchangeItem(
             war_supply_item_id, 0,
             give_ids, give_qtys
         )

--- a/Widgets/Coding/Py4GW_DEMO.py
+++ b/Widgets/Coding/Py4GW_DEMO.py
@@ -282,7 +282,7 @@ def ShowMerchantWindow():
                     PyImGui.table_set_column_index(0)
 
                     if PyImGui.button("Exchange Item"):
-                        GLOBAL_CACHE.Trading.Collector.ExghangeItem(item_id, cost, trade_item_list, quantity_list)
+                        GLOBAL_CACHE.Trading.Collector.ExchangeItem(item_id, cost, trade_item_list, quantity_list)
                     PyImGui.end_table()
 
         PyImGui.end()

--- a/Widgets/Guild Wars/Items & Loot/SuperItemEater.py
+++ b/Widgets/Guild Wars/Items & Loot/SuperItemEater.py
@@ -522,7 +522,7 @@ def _run_exchange(exchange: CollectorExchange):
         give_ids, give_qtys = _build_turn_in(stacks, exchange.exchange_rate)
         if not give_ids:
             break
-        GLOBAL_CACHE.Trading.Collector.ExghangeItem(receive_item_id, 0, give_ids, give_qtys)
+        GLOBAL_CACHE.Trading.Collector.ExchangeItem(receive_item_id, 0, give_ids, give_qtys)
         elapsed = 0
         while not GLOBAL_CACHE.Trading.IsTransactionComplete() and elapsed < _TRANSACTION_TIMEOUT_MS:
             yield from Routines.Yield.wait(100)


### PR DESCRIPTION
Multiple updates across core libs:

- Merchant/Trading: fixed typo ExghangeItem -> ExchangeItem, added frame_cache decorators to various GetOfferedItems methods, and wired TradingCache ExchangeItem to action queue.
- Item: added Gender enum import, added GetCompositeModelIDs and GetTrueModelFileID helpers to resolve composite model IDs by gender.
- enums_src/GameData_enums: introduced Gender enum and Attribute.is_primary property; reordered profession attribute lists.
- enums_src/Item_enums: added INVENTORY_BAGS and STORAGE_BAGS, ItemType.item_types helper, new ItemAction and SalvageMode enums, and reorganized rune/upgrade identifiers and groupings to list-based mappings to support multiple ids.
- item_mods_src/types: added typing helpers, ModifierType, any_of(), renamed some ModifierIdentifier values (including Empty) and updated identifier constants.
- item_mods_src/item_modifier_parser: improved property building with robust error handling, better handling of Prefix/Suffix/Inscription upgrades and inherent upgrade composition, and added EmptyProperty fallback.
- item_mods_src/properties: added EmptyProperty, renamed some fields/classes (e.g. EnergyRecovery), clarified encoded descriptions and fixed several field usages.
- item_mods_src/upgrade_parser: changed upgrade selection to consider multiple creators and pick best match by specificity, adjusted factory mapping to new modifier names and behaviors.
- native/.gitignore: ignore Sources/frenkeyLib/Scripts/output.

These changes improve robustness of modifier/upgrade parsing, add model/gender helpers, clean up enums and naming, and add caching instrumentation for merchant item retrieval.