### PR TITLE
Added missing Wrappers to BT.Wrappers, updated Junundu Combat

### DIFF
--- a/HeroAI/combat.py
+++ b/HeroAI/combat.py
@@ -233,6 +233,7 @@ class CombatClass:
         self.unknown_junundu_ability = GLOBAL_CACHE.Skill.GetID("Unknown_Junundu_Ability")
         self.leave_junundu = GLOBAL_CACHE.Skill.GetID("Leave_Junundu")
         self.junundu_tunnel = GLOBAL_CACHE.Skill.GetID("Junundu_Tunnel")
+        self.junundu_siege = GLOBAL_CACHE.Skill.GetID("Junundu_Siege") or 1441
 
     @staticmethod
     def _normalize_weapon_requirement_name(value: str) -> str:
@@ -786,6 +787,10 @@ class CombatClass:
             v_target = GetEnemyKnockedDown(self.get_combat_distance())
             if v_target == 0 and not targeting_strict:
                 v_target = get_nearest_enemy()
+        elif target_allegiance == Skilltarget.EnemyNotNearby:
+            v_target = Routines.Agents.GetNearestEnemyOutsideRange(Range.Nearby.value, self.get_combat_distance())
+            if v_target == 0 and not targeting_strict:
+                v_target = get_nearest_enemy()
         elif target_allegiance == Skilltarget.AllyMartialRanged:
             v_target = Routines.Agents.GetNearestEnemyRanged(self.get_combat_distance())
             if v_target == 0 and not targeting_strict:
@@ -1081,6 +1086,10 @@ class CombatClass:
 
             if (self.skills[slot].skill_id == self.junundu_tunnel):
                 return Routines.Agents.GetNearestEnemy(self.get_combat_distance()) == 0
+
+            if (self.skills[slot].skill_id == self.junundu_siege):
+                return (Routines.Agents.GetNearestEnemy(Range.Nearby.value) != 0 and
+                        Routines.Agents.GetNearestEnemyOutsideRange(Range.Nearby.value, Range.Earshot.value) != 0)
 
             if ((self.skills[slot].skill_id == self.unknown_junundu_ability) or
                 (self.skills[slot].skill_id == self.leave_junundu)

--- a/HeroAI/custom_skill_src/pve.py
+++ b/HeroAI/custom_skill_src/pve.py
@@ -972,7 +972,15 @@ class PVESkills:
         skill.TargetAllegiance = Skilltarget.EnemyKnockedDown.value
         skill.Nature = SkillNature.Offensive.value
         skill_data[skill.SkillID] = skill
-        
+
+        skill = CustomSkill()
+        skill.SkillID = GLOBAL_CACHE.Skill.GetID("Junundu_Siege") or 1441
+        skill.SkillType = SkillType.Attack.value
+        skill.TargetAllegiance = Skilltarget.EnemyNotNearby.value
+        skill.Nature = SkillNature.Offensive.value
+        skill.Conditions.UniqueProperty = True
+        skill_data[skill.SkillID] = skill
+
         skill = CustomSkill()
         skill.SkillID = GLOBAL_CACHE.Skill.GetID("Unknown_Junundu_Ability")
         skill.SkillType = SkillType.Attack.value

--- a/HeroAI/types.py
+++ b/HeroAI/types.py
@@ -143,6 +143,7 @@ class Skilltarget (IntEnum):
     NonWeaponSpelledAlly = 39
     ResurrectionAlly = 40
     HexedAlly = 41
+    EnemyNotNearby = 42
 
 
 

--- a/Py4GWCoreLib/SkillManager.py
+++ b/Py4GWCoreLib/SkillManager.py
@@ -84,6 +84,7 @@ class UniqueSkills:
         self.unknown_junundu_ability = GLOBAL_CACHE.Skill.GetID("Unknown_Junundu_Ability")
         self.leave_junundu = GLOBAL_CACHE.Skill.GetID("Leave_Junundu")
         self.junundu_tunnel = GLOBAL_CACHE.Skill.GetID("Junundu_Tunnel")
+        self.junundu_siege = GLOBAL_CACHE.Skill.GetID("Junundu_Siege") or 1441
         #nightfall
         self.vial_of_purified_water = 1417
         self.harbinger_model_ids = {5458, 5459, 5460}  # Harbinger model IDs
@@ -429,7 +430,11 @@ def _GetAppropiateTarget(
         elif target_allegiance == Skilltarget.EnemyKnockedDown:
             v_target = _GetEnemyKnockedDown(combat_distance)
             if v_target == 0 and not targeting_strict:
-                v_target = nearest_enemy           
+                v_target = nearest_enemy
+        elif target_allegiance == Skilltarget.EnemyNotNearby:
+            v_target = Routines.Agents.GetNearestEnemyOutsideRange(Range.Nearby.value, combat_distance)
+            if v_target == 0 and not targeting_strict:
+                v_target = nearest_enemy
         elif target_allegiance == Skilltarget.AllyMartialRanged:
             v_target = Routines.Agents.GetNearestEnemyRanged(combat_distance)
             if v_target == 0 and not targeting_strict:
@@ -627,14 +632,18 @@ def _AreCastConditionsMet(slot,
                 return Agent.IsHexed(Player.GetAgentID()) or Agent.IsConditioned(Player.GetAgentID())
 
             if (skills[slot].skill_id == unique_skills.junundu_wail):
+                if Routines.Agents.GetDeadAlly(Range.Earshot.value) != 0:
+                    return True
                 life = Agent.GetHealth(Player.GetAgentID()) < Conditions.LessLife
-                ooc = Routines.Agents.GetNearestEnemy(Range.Earshot.value) == 0
-                nearest_corpse = Routines.Agents.GetNearestCorpse(Range.Earshot.value)
-                return (life and ooc) #or (nearest_corpse != 0)
+                return life and Routines.Agents.GetNearestEnemy(Range.Earshot.value) == 0
 
             if (skills[slot].skill_id == unique_skills.junundu_tunnel):
                 return Routines.Agents.GetNearestEnemy(Range.Earshot.value) == 0
-            
+
+            if (skills[slot].skill_id == unique_skills.junundu_siege):
+                return (Routines.Agents.GetNearestEnemy(Range.Nearby.value) != 0 and
+                        Routines.Agents.GetNearestEnemyOutsideRange(Range.Nearby.value, Range.Earshot.value) != 0)
+
             if ((skills[slot].skill_id == unique_skills.unknown_junundu_ability) or
                 (skills[slot].skill_id == unique_skills.leave_junundu)
                 ):
@@ -1526,6 +1535,10 @@ class SkillManager:
                     v_target = get_nearest_enemy()
             elif target_allegiance == Skilltarget.EnemyKnockedDown:
                 v_target = Routines.Targeting.GetEnemyKnockedDown(self.get_combat_distance())
+                if v_target == 0 and not targeting_strict:
+                    v_target = get_nearest_enemy()
+            elif target_allegiance == Skilltarget.EnemyNotNearby:
+                v_target = Routines.Agents.GetNearestEnemyOutsideRange(Range.Nearby.value, self.get_combat_distance())
                 if v_target == 0 and not targeting_strict:
                     v_target = get_nearest_enemy()
             elif target_allegiance == Skilltarget.EnemyMartialRanged:

--- a/Py4GWCoreLib/routines_src/Agents.py
+++ b/Py4GWCoreLib/routines_src/Agents.py
@@ -262,6 +262,21 @@ class Agents:
         return Utils.GetFirstFromArray(enemy_array)
 
     @staticmethod
+    def GetNearestEnemyOutsideRange(min_distance=0.0, max_distance=4500.0, aggressive_only=False):
+        from ..AgentArray import AgentArray
+        from ..Py4GWcorelib import Utils
+        from ..EnemyBlacklist import EnemyBlacklist
+
+        bl = EnemyBlacklist()
+        player_pos = Player.GetXY()
+        enemy_array = Agents.GetFilteredEnemyArray(player_pos[0], player_pos[1], max_distance, aggressive_only)
+        if not bl.is_empty():
+            enemy_array = AgentArray.Filter.ByCondition(enemy_array, lambda agent_id: not bl.is_blacklisted(agent_id))
+        enemy_array = AgentArray.Filter.ByDistance(enemy_array, player_pos, min_distance, negate=True)
+        enemy_array = AgentArray.Sort.ByDistance(enemy_array, player_pos)
+        return Utils.GetFirstFromArray(enemy_array)
+
+    @staticmethod
     def GetFilteredAllyArray(x, y, max_distance=4500.0, other_ally=False):
         from ..AgentArray import AgentArray
         from ..Agent import Agent

--- a/Sources/ApoSource/ApoBottingLib/wrappers.py
+++ b/Sources/ApoSource/ApoBottingLib/wrappers.py
@@ -1457,6 +1457,12 @@ def FlagAllHeroes(x: float, y: float) -> BehaviorTree:
 def FlagHeroesFromList(hero_positions: list[int | str] | None, x: float, y: float, flag_all: bool = False) -> BehaviorTree:
     return RoutinesBT.Party.FlagHeroesFromList(hero_positions=hero_positions, x=x, y=y, flag_all=flag_all,)
 
+def UnflagAllHeroes(log: bool = False, aftercast_ms: int = 125) -> BehaviorTree:
+    return RoutinesBT.Party.UnflagAllHeroes(log=log, aftercast_ms=aftercast_ms)
+
+def DropBundle(log: bool = False) -> BehaviorTree:
+    return RoutinesBT.Party.DropBundle(log=log)
+
 def WaitForActiveQuest(quest_id: int, timeout_ms: int = 1500, throttle_interval_ms: int = 150) -> BehaviorTree:
     return RoutinesBT.Party.WaitForActiveQuest(quest_id=quest_id,timeout_ms=timeout_ms,throttle_interval_ms=throttle_interval_ms,)
 


### PR DESCRIPTION
- Add GetNearestEnemyOutsideRange to Routines.Agents (Agents.py) with EnemyBlacklist support
- Register Junundu Siege as CustomSkill with UniqueProperty + EnemyNotNearby targeting (pve.py)
- Add junundu_siege to UniqueSkills and implement UniqueProperty condition in SkillManager.py and combat.py: fires only when a melee-range enemy exists AND a separate earshot-range enemy exists outside Nearby range
- Add UnflagAllHeroes and DropBundle wrappers to Sources/ApoSource/ApoBottingLib/wrappers.py