### PR TITLE
Flagbugfix

### DIFF
--- a/HeroAI/follow/follower_runtime.py
+++ b/HeroAI/follow/follower_runtime.py
@@ -29,6 +29,7 @@ class FollowExecutionState:
     last_recovery_follow_command_ms: int = 0
     recovery_detour_attempted: bool = False
     pet_recovery_notified: bool = False
+    relocating_to_flag: bool = False
     stuck: SmartUnstuckState = field(default_factory=SmartUnstuckState)
 
 
@@ -54,11 +55,13 @@ def get_follow_destination_xy(cached_data: CacheData) -> tuple[float, float] | N
         return abs(float(x)) > 0.001 or abs(float(y)) > 0.001
 
     published_follow_xy = (float(options.FollowPos.x), float(options.FollowPos.y))
+    flag_xy = (float(options.FlagPos.x), float(options.FlagPos.y))
+    is_flagged = bool(getattr(options, "IsFlagged", False))
     if _is_nonzero_xy(*published_follow_xy):
         return published_follow_xy
 
-    if bool(getattr(options, "IsFlagged", False)) and _is_nonzero_xy(float(options.FlagPos.x), float(options.FlagPos.y)):
-        return (float(options.FlagPos.x), float(options.FlagPos.y))
+    if is_flagged and _is_nonzero_xy(*flag_xy):
+        return flag_xy
 
     return None
 
@@ -151,6 +154,7 @@ def execute_follower_follow(
         state.last_follow_assigned_point = None
         state.last_recovery_follow_command_ms = 0
         state.recovery_detour_attempted = False
+        state.relocating_to_flag = False
         reset_smart_unstuck(state.stuck)
 
     def _account_map_signature(account) -> tuple[int, int, int, int, int] | None:
@@ -304,6 +308,14 @@ def execute_follower_follow(
         state.last_follow_move_point = None
     state.last_follow_assigned_point = assigned_point
 
+    # A flag re-position (assigned point moved) takes priority over combat: the
+    # follower must walk to the new flag even mid-fight. Latch a relocation
+    # state that is cleared once the follower arrives, so it keeps moving across
+    # ticks instead of re-yielding to local aggro after the one-tick
+    # assigned_changed pulse.
+    if (own_flag_active or all_flag_active) and assigned_changed:
+        state.relocating_to_flag = True
+
     # Upstream "follow recovery": when the follower is far from its destination,
     # tighten the tolerance to FOLLOW_RECOVERY_RELEASE_DISTANCE so it keeps
     # closing the gap instead of stopping at the normal slot threshold.
@@ -314,10 +326,35 @@ def execute_follower_follow(
     # radius of Adjacent so followers that have reached the flag can fight.
     if (own_flag_active or all_flag_active) and effective_follow_distance < float(Range.Adjacent.value):
         effective_follow_distance = float(Range.Adjacent.value)
-    if Utils.Distance((follow_x, follow_y), Player.GetXY()) <= effective_follow_distance:
+    dist_to_follow = Utils.Distance((follow_x, follow_y), Player.GetXY())
+    if dist_to_follow <= effective_follow_distance:
         state.last_recovery_follow_command_ms = 0
         state.recovery_detour_attempted = False
+        state.relocating_to_flag = False
         reset_smart_unstuck(state.stuck)
+        return BehaviorTree.NodeState.FAILURE
+
+    # Flagged followers: yield to HandleCombat only while there are enemies in
+    # range of THIS follower (local aggro), not party-wide aggro. Holding
+    # position makes Follow win the selector, which both blocks combat AND
+    # leaves the follower idle once the engine move is interrupted by aggro.
+    # Gating on local aggro (instead of the party-driven `in_aggro`) lets a
+    # follower with no nearby enemies walk back to its flag even while the rest
+    # of the party fights elsewhere. While relocating to a freshly moved flag,
+    # do NOT yield — the flag move must win over combat. Recovery (dist >=
+    # Spirit) is handled below and also takes priority over fighting.
+    if (
+        (own_flag_active or all_flag_active)
+        and bool(cached_data.data.local_in_aggro)
+        and not recovery_active
+        and not state.relocating_to_flag
+    ):
+        # Drop the cached move point so that once combat ends the arrival/move
+        # path below re-issues Player.Move toward the flag instead of skipping
+        # it via the "already moved here" dedup — otherwise a follower that
+        # chased an enemy away stays put after combat instead of returning.
+        state.last_follow_move_point = None
+        cached_data.follow_throttle_timer.Reset()
         return BehaviorTree.NodeState.FAILURE
 
     if follow_z == 0 and not own_flag_active:
@@ -340,6 +377,17 @@ def execute_follower_follow(
         return follow_active_state
 
     if recovery_active:
+        if own_flag_active or all_flag_active:
+            # Flagged followers have a fixed world destination (the flag), so
+            # recover by walking straight to it. The detour/engine-follow
+            # recovery below is meant for leader-following; for the flag case it
+            # never issues a move command, leaving a far-flagged follower
+            # standing still even when the leader is far away.
+            if ActionQueueManager().IsEmpty("ACTION"):
+                Player.Move(follow_x, follow_y)
+                state.last_follow_move_point = (follow_x, follow_y)
+            cached_data.follow_throttle_timer.Reset()
+            return follow_active_state
         if not state.recovery_detour_attempted:
             force_front_detour(
                 state.stuck,
@@ -349,9 +397,6 @@ def execute_follower_follow(
             )
             state.recovery_detour_attempted = True
             state.last_recovery_follow_command_ms = 0
-            cached_data.follow_throttle_timer.Reset()
-            return follow_active_state
-        if own_flag_active or all_flag_active:
             cached_data.follow_throttle_timer.Reset()
             return follow_active_state
         now_ms = int(Utils.GetBaseTimestamp())

--- a/HeroAI/follow/follower_runtime.py
+++ b/HeroAI/follow/follower_runtime.py
@@ -308,6 +308,12 @@ def execute_follower_follow(
     # tighten the tolerance to FOLLOW_RECOVERY_RELEASE_DISTANCE so it keeps
     # closing the gap instead of stopping at the normal slot threshold.
     effective_follow_distance = min(follow_distance, FOLLOW_RECOVERY_RELEASE_DISTANCE) if recovery_active else follow_distance
+    # When flagged the published threshold is 0.0 (hold position exactly), which
+    # makes the arrival check below impossible to satisfy and permanently blocks
+    # HandleCombat in the headless tree selector.  Enforce a minimum arrival
+    # radius of Adjacent so followers that have reached the flag can fight.
+    if (own_flag_active or all_flag_active) and effective_follow_distance < float(Range.Adjacent.value):
+        effective_follow_distance = float(Range.Adjacent.value)
     if Utils.Distance((follow_x, follow_y), Player.GetXY()) <= effective_follow_distance:
         state.last_recovery_follow_command_ms = 0
         state.recovery_detour_attempted = False


### PR DESCRIPTION
fix: restore flagged follower movement and combat behaviour
Since https://github.com/apoguita/Py4GW/commit/e30a07bb294222cea505f2e4765faaec17af3fd9 flagged followers regressed in several ways. The flag-guard
"anchor" logic plus the follow/combat selector interaction left followers
standing idle and not fighting in a number of situations. This reworks the
flagged branch of execute_follower_follow so the follower reliably moves to
its flag, fights when appropriate, and returns to the flag afterwards -
independently of where the leader is.

Fixes (each confirmed with runtime logs):

- Far flag -> standing still: in the recovery branch a flagged follower only
  returned follow_active_state without ever issuing Player.Move (the detour /
  engine-follow recovery is meant for leader-following and never moved toward
  a fixed flag). It now walks straight to the flag, so a follower flagged far
  away - even with the leader far off - actually travels there.

- In-combat drift -> combat disabled + idle: while away from the flag, Follow
  won the selector and blocked HandleCombat, while the move-dedup suppressed
  re-issuing Player.Move. Flagged followers now yield to HandleCombat when
  there are enemies in range, so they fight instead of holding position.

- No return after combat: the combat yield was gated on the party-driven
  in_aggro (kept true by party aggro / stay-alert), so a follower with no
  nearby enemies never walked back. It is now gated on local_in_aggro, and the
  cached move point is cleared on yield so the return move is not skipped by
  the dedup. A follower with no local enemies returns to its flag even while
  the rest of the party is still fighting.

- Flag repositioned mid-combat -> ignored: a new relocating_to_flag latch is
  set when the assigned flag point changes and cleared on arrival. While
  relocating, the follower does not yield to combat, so moving the flag during
  a fight makes the follower walk to the new position and resume fighting once
  it arrives.

Priority order for flagged followers: relocating to a moved flag > fighting
local enemies > returning to the flag, with long-range recovery still taking
over beyond Spirit range.