### PR TITLE
fix: salvage confirm offset -> 113 after GW update

### DIFF
--- a/Py4GWCoreLib/Inventory.py
+++ b/Py4GWCoreLib/Inventory.py
@@ -398,7 +398,7 @@ class Inventory:
         from .UIManager import UIManager
 
         parent_hash = 140452905
-        yes_button_offsets = [6,110,6]
+        yes_button_offsets = [6,113,6]
         
         salvage_material_window = UIManager.GetChildFrameID(parent_hash, yes_button_offsets)
         UIManager.FrameClick(salvage_material_window)

--- a/Sources/frenkeyLib/ItemHandling/UIManagerExtensions.py
+++ b/Sources/frenkeyLib/ItemHandling/UIManagerExtensions.py
@@ -45,6 +45,7 @@ class UIManagerExtensions:
         candidate_frame_ids = [
             UIManager.GetChildFrameID(140452905, [6, 110, 6]),
             UIManager.GetChildFrameID(140452905, [6, 111, 6]),
+            UIManager.GetChildFrameID(140452905, [6, 113, 6]),
             UIManager.GetChildFrameID(140452905, [6, 100, 6]),
             UIManager.GetChildFrameID(684387150, [0, 6]),
         ]


### PR DESCRIPTION
GW update shifted the salvage confirm window's child offset under 140452905,6 (+2), so the hard-coded [6,110,6]/[6,111,6] paths no longer hit the Yes button and the confirm (0x7A) was never sent - gold/purple salvage failed (AutoSalvage) / disconnected (InventoryPlus).

- AcceptSalvageMaterialsWindow: [6,110,6] -> [6,113,6]
- frenkeyLib UIManagerExtensions: add [6,113,6] candidate