### PR TITLE
HeroAI: call targets for custom-build characters too

### DIFF
--- a/HeroAI/combat.py
+++ b/HeroAI/combat.py
@@ -2017,9 +2017,6 @@ class CombatClass:
         """
         Execute the first castable skill in the prioritized skill order.
         """
-        if not ooc:
-            self._maybe_call_leader_selected_target(cached_data)
-
         slot, target_agent_id = self.FindCastableSkill(ooc=ooc)
         if slot < 0:
             self.ResetSkillPointer()

--- a/Py4GWCoreLib/Builds/Any/HeroAI.py
+++ b/Py4GWCoreLib/Builds/Any/HeroAI.py
@@ -151,6 +151,10 @@ class HeroAI_Build(BuildMgr):
             yield from Routines.Yield.wait(250)
             return
 
+        # Leader auto-call-target for both generic and custom builds (custom builds bypass HandleCombat).
+        if is_in_combat:
+            cached_data.combat_handler._maybe_call_leader_selected_target(cached_data)
+
         if contract_build is self:
             if cached_data.combat_handler.HandleCombat(cached_data, ooc=not is_in_combat):
                 self.SetTickSuccess()


### PR DESCRIPTION
## Problem

The leader auto-call-target (`_maybe_call_leader_selected_target`) is only invoked inside `CombatClass.HandleCombat`, which is the **generic HeroAI** combat path. A character that resolves to a registered custom build (via `EnsureBuildContract` / `ScoreMatch`) runs combat through `contract_build.ProcessCombat()` in `HeroAI_Build._run_contract` and **never reaches `HandleCombat`** — so it casts skills normally but never calls a target for the party/heroes to focus.

In practice this looks like "HeroAI stopped calling targets" the moment a character's skillbar starts matching a bundled custom build (e.g. a Paragon equipping Heroic Refrain matches `Paragon_Refrain` in `Builds/Paragon/P_W/Defensive Refrain.py`).

Timeline suggests a placement gap rather than intended behavior: custom-build support landed in `78302ada` (2026-03-16); the auto-call feature landed later in `d6464302` (2026-05-25) and was only wired into the generic path.

## Fix

Invoke the auto-call once per combat tick in `HeroAI_Build._run_contract`, before the generic/custom branch, so it runs for **both** paths. Removed the now-redundant call from `CombatClass.HandleCombat`.

- **No double-call / no change for generic builds:** `CombatClass.HandleCombat` has a single caller (`_run_contract`'s generic branch), so the invocation simply moved up one frame.
- **Multibox-safe:** `MaybeCallCombatTarget` already self-gates on `AutoCallTargets`, **party-leader**, alive, and `MapValid`, so followers and non-leaders stay no-ops regardless of build — only the party leader ever issues the call.
- Fixes both the Modular Tester and the standalone HeroAI widget, since both run combat through `HeroAI_Build.ProcessCombat`.

## Testing

Live-tested on a Paragon resolving to `Paragon_Refrain` in HM dungeon combat: before, no target was ever called; after, the party-called target updates each fight and heroes focus-fire it (`Party.GetPartyTarget()` matches the leader's selected enemy). Generic-build characters and follower/non-leader clients behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
