### PR TITLE
Fix Item.Customization.GetUpgrade instance matching for upgrade value checks

### DIFF
--- a/Py4GWCoreLib/Item.py
+++ b/Py4GWCoreLib/Item.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional, Type, TypeVar
+from typing import Iterable, Optional, Type
 
 import PyItem
 import PyInventory
@@ -7,12 +7,11 @@ from enum import Enum
 
 from Py4GWCoreLib.enums_src.GameData_enums import Attribute, DyeColor, Gender
 from Py4GWCoreLib.enums_src.Item_enums import DAMAGE_RANGES, ItemType, Rarity
+from Py4GWCoreLib.item_mods_src._typing import TUpgrade
 from Py4GWCoreLib.item_mods_src.item_mod import ItemMod
 from Py4GWCoreLib.item_mods_src.item_modifier_parser import ItemModifierParser
 from Py4GWCoreLib.item_mods_src.properties import ArmorProperty, AttributeRequirement, DamageProperty, EnergyProperty
 from Py4GWCoreLib.item_mods_src.upgrades import Upgrade
-
-UpgradeType = TypeVar("UpgradeType", bound="Upgrade")
 
 class Bag(Enum):
     NoBag = 0
@@ -482,7 +481,7 @@ class Item:
                 return Item.item_instance(item_id).is_sparkly
 
             @staticmethod
-            def GetUpgrade(item_id, upgrade : Type[UpgradeType] | Upgrade) -> Optional[UpgradeType] | None:
+            def GetUpgrade(item_id, upgrade : Type[TUpgrade] | TUpgrade) -> Optional[TUpgrade]:
                 """Gets a specific upgrade of an item by its ID and upgrade type.
                 Args:
                     item_id (int): The ID of the item to check for the upgrade.
@@ -490,7 +489,7 @@ class Item:
                 Returns:
                     Upgrade | None: The upgrade of the specified type if found, otherwise None.
                 """
-                existing_upgrade : Optional[UpgradeType] = ItemMod.get_upgrade(item_id, upgrade)
+                existing_upgrade : Optional[TUpgrade] = ItemMod.get_upgrade(item_id, upgrade)
                 return existing_upgrade
             
             @staticmethod
@@ -505,7 +504,7 @@ class Item:
                 return inherent_upgrades is not None and len(inherent_upgrades) > 0
             
             @staticmethod
-            def HasUpgradeType(item_id, upgrade_type : Type[UpgradeType], max : bool = False) -> bool:
+            def HasUpgradeType(item_id, upgrade_type : Type[TUpgrade], max : bool = False) -> bool:
                 """Purpose: Check if an item has a specific upgrade type by its ID."""             
                                   
                 if (upgrade := Item.Customization.GetUpgrade(item_id, upgrade_type)) is not None:

--- a/Py4GWCoreLib/item_mods_src/_typing.py
+++ b/Py4GWCoreLib/item_mods_src/_typing.py
@@ -1,0 +1,5 @@
+from typing import TypeVar
+
+from Py4GWCoreLib.item_mods_src.upgrades import Upgrade
+
+TUpgrade = TypeVar('TUpgrade', bound=Upgrade)

--- a/Py4GWCoreLib/item_mods_src/item_mod.py
+++ b/Py4GWCoreLib/item_mods_src/item_mod.py
@@ -1,20 +1,55 @@
-from typing import Optional, Type, TypeVar
+from typing import Optional, Type, cast
 
 from PyItem import ItemModifier
 
 from Py4GWCoreLib.enums_src.Item_enums import ItemType, Rarity
 from Py4GWCoreLib.item_mods_src.item_modifier_parser import ItemModifierParser
 from Py4GWCoreLib.item_mods_src.properties import InherentProperty, InscriptionProperty, ItemProperty, PrefixProperty, SuffixProperty, TargetItemTypeProperty
+from Py4GWCoreLib.item_mods_src._typing import TUpgrade
 from Py4GWCoreLib.item_mods_src.types import ItemUpgradeType
 from Py4GWCoreLib.item_mods_src.upgrades import Upgrade
 from Py4GWCoreLib.py4gwcorelib_src.FrameCache import frame_cache
 
 class ItemMod:
-    T = TypeVar("T", bound="Upgrade")
+    @staticmethod
+    def _same_enum_identity(left: object, right: object) -> bool:
+        if left is right:
+            return True
+
+        left_type = type(left)
+        right_type = type(right)
+        return (
+            left_type.__module__ == right_type.__module__
+            and left_type.__qualname__ == right_type.__qualname__
+            and getattr(left, 'name', None) == getattr(right, 'name', None)
+            and getattr(left, 'value', None) == getattr(right, 'value', None)
+        )
 
     @staticmethod
-    @frame_cache(category="ItemMod", source_lib="get_upgrade")
-    def get_upgrade(item_id : int, upgrade: Type[T] | T) -> Optional[T]:
+    def _same_upgrade_type(candidate: Upgrade, expected_type: type[Upgrade]) -> bool:
+        candidate_type = type(candidate)
+        if candidate_type is expected_type:
+            return True
+
+        return (
+            candidate_type.__module__ == expected_type.__module__
+            and candidate_type.__qualname__ == expected_type.__qualname__
+            and ItemMod._same_enum_identity(getattr(candidate_type, 'id', None), getattr(expected_type, 'id', None))
+            and ItemMod._same_enum_identity(getattr(candidate_type, 'mod_type', None), getattr(expected_type, 'mod_type', None))
+        )
+
+    @staticmethod
+    def _same_upgrade_value(left: object, right: object) -> bool:
+        left_comparison_data = getattr(left, '_comparison_data', None)
+        right_comparison_data = getattr(right, '_comparison_data', None)
+        return (
+            callable(left_comparison_data)
+            and callable(right_comparison_data)
+            and left_comparison_data() == right_comparison_data()
+        )
+
+    @staticmethod
+    def get_upgrade(item_id : int, upgrade: Type[TUpgrade] | TUpgrade | Upgrade) -> Optional[TUpgrade]:
         '''
         Gets the upgrade of the specified type from the item properties. This is a helper method that combines the logic of getting the item modifiers, parsing them into properties, and extracting the relevant upgrade property. It also includes validation for inherent upgrades on green items.
         Recommended usage is with an assignment expression to avoid unnecessary processing if the upgrade is not present or of the wrong type.
@@ -25,38 +60,33 @@ class ItemMod:
         '''
         
         prefix, suffix, inscription, inherent = ItemMod.get_item_upgrades(item_id)
-        upgrade_type = upgrade if isinstance(upgrade, type) else type(upgrade)
-        desired_upgrade = upgrade if isinstance(upgrade, Upgrade) else None
+        desired_upgrade = None if isinstance(upgrade, type) else upgrade
+        desired_upgrade_type = upgrade if isinstance(upgrade, type) else type(upgrade)
 
-        if prefix and isinstance(prefix, upgrade_type):
-            if desired_upgrade:
-                if desired_upgrade.matches(prefix):
-                    return prefix
-            else:
-                return prefix
+        def find_match(candidate: Upgrade | None) -> Optional[TUpgrade]:
+            if candidate is None:
+                return None
 
-        if suffix and isinstance(suffix, upgrade_type):
-            if desired_upgrade:
-                if desired_upgrade.matches(suffix):
-                    return suffix
-            else:
-                return suffix
+            if not ItemMod._same_upgrade_type(candidate, desired_upgrade_type):
+                return None
 
-        if inscription and isinstance(inscription, upgrade_type):
-            if desired_upgrade:
-                if desired_upgrade.matches(inscription):
-                    return inscription
-            else:
-                return inscription
-        
+            if desired_upgrade is not None and not ItemMod._same_upgrade_value(candidate, desired_upgrade):
+                return None
+
+            return cast(TUpgrade, candidate)
+
+        if (matched_prefix := find_match(prefix)) is not None:
+            return matched_prefix
+
+        if (matched_suffix := find_match(suffix)) is not None:
+            return matched_suffix
+
+        if (matched_inscription := find_match(inscription)) is not None:
+            return matched_inscription
+
         for inh in inherent or []:
-            if inh and isinstance(inh, upgrade_type):
-                if desired_upgrade:
-                    if desired_upgrade.matches(inh):
-                        return inh
-                else:
-                    return inh
-
+            if (matched_inherent := find_match(inh)) is not None:
+                return matched_inherent
         return None
     
     @staticmethod

--- a/Py4GWCoreLib/item_mods_src/upgrades.py
+++ b/Py4GWCoreLib/item_mods_src/upgrades.py
@@ -384,8 +384,22 @@ class Upgrade:
         }
         return type(self).__name__, tuple(sorted(comparison_values.items()))
 
+    @staticmethod
+    def _same_semantic_type(other: object, expected_type: type['Upgrade']) -> bool:
+        other_type = type(other)
+        if other_type is expected_type:
+            return True
+
+        return (
+            other_type.__module__ == expected_type.__module__
+            and other_type.__qualname__ == expected_type.__qualname__
+            and getattr(other_type, 'id', None) == getattr(expected_type, 'id', None)
+            and getattr(other_type, 'mod_type', None) == getattr(expected_type, 'mod_type', None)
+        )
+
     def equals(self, other: object) -> bool:
-        return isinstance(other, Upgrade) and self._comparison_data() == other._comparison_data()
+        other_comparison_data = getattr(other, '_comparison_data', None)
+        return callable(other_comparison_data) and self._comparison_data() == other_comparison_data()
 
     def matches(self, other: object) -> bool:
         return self.equals(other)
@@ -1160,10 +1174,10 @@ class OfAttributeUpgrade(WeaponSuffix):
 
     def equals(self, other: object) -> bool:
         return (
-            isinstance(other, OfAttributeUpgrade)
-            and self.attribute == other.attribute
-            and self.attribute_level == other.attribute_level
-            and self.chance == other.chance
+            Upgrade._same_semantic_type(other, OfAttributeUpgrade)
+            and self.attribute == other.attribute  # type: ignore
+            and self.attribute_level == other.attribute_level  # type: ignore
+            and self.chance == other.chance  # type: ignore
         )
 
     def matches(self, other: object) -> bool:
@@ -2649,12 +2663,12 @@ class OfTheProfessionUpgrade(WeaponSuffix):
     def create_encoded_name(self) -> GWStringEncoded:
         return GWStringEncoded(self.get_text_color(True) + GWEncoded.STR1_OF_STR2 + GWEncoded.PLACEHOLDER_TO_REMOVE + GWEncoded.THE_PROFESSION.get(self.profession, bytes()), f"of {self.profession.name if self.profession != Profession._None else 'Unknown Profession'}", GWEncoded.PLACEHOLDER_TO_REMOVE, ["", self.profession.name if self.profession != Profession._None else "Profession"])
 
-    def equals(self, other: object) -> bool:
+    def equals(self, other: object) -> bool:        
         return (
-            isinstance(other, OfTheProfessionUpgrade)
-            and self.profession == other.profession
-            and self.attribute == other.attribute
-            and self.attribute_level == other.attribute_level
+            Upgrade._same_semantic_type(other, OfTheProfessionUpgrade)
+            and self.profession == other.profession # type: ignore
+            and self.attribute == other.attribute # type: ignore
+            and self.attribute_level == other.attribute_level # type: ignore
         )
 
     def matches(self, other: object) -> bool:


### PR DESCRIPTION
## Summary

This fixes incorrect upgrade lookup behavior in `Item.Customization.GetUpgrade` / `ItemMod.get_upgrade` when passing an upgrade instance instead of an upgrade class.

The bug showed up most clearly with item suffixes like `OfDevotionUpgrade`:
- class lookup could find the correct upgrade on the item
- instance lookup could still behave incorrectly
- a `44` HP devotion probe and a `45` HP devotion probe could both match the same `44` HP item
- in other cases, reload/import differences caused valid instance matches to fail

## Issue

Upgrade lookup had a few overlapping problems:

1. Type matching was inconsistent between class-based and instance-based lookups.
2. Some matching paths depended on Python class identity or `isinstance(...)` in ways that were fragile across reloads/import surfaces.
3. Instance matching logic had drifted into nested branches that could return upgrades too loosely or compare in the wrong order.
4. This made value-sensitive upgrade checks unreliable, especially when the caller expected exact instance semantics.

Example:
- `OfDevotionUpgrade(health=44)` should match a `+44 Health (while Enchanted)` suffix
- `OfDevotionUpgrade(health=45)` should not
- previously both could match the same item

## Solution

The upgrade lookup path was simplified and made deterministic.

`ItemMod.get_upgrade` now uses one clear rule set:
- if the caller passes an upgrade class, lookup matches by semantic upgrade type
- if the caller passes an upgrade instance, lookup matches by:
  - semantic upgrade type
  - full normalized comparison payload (`_comparison_data()`)

This removes the ambiguous nested matching behavior and makes instance lookup behave like an exact upgrade-value query.

The semantic type check also avoids brittle raw class-object identity comparisons, which helps when upgrade objects come from different reload/import generations.

## Why This Matters

A lot of item handling logic depends on distinguishing:
- upgrade family
- exact upgrade roll/value
- inherent vs suffix/inscription behavior

If instance lookup is unreliable, then filters, salvage rules, item evaluation, and debugging tools can all produce misleading results. This fix makes upgrade matching predictable and safe for both:
- “does this item have this kind of upgrade?”
- “does this item have this exact rolled upgrade?”

## What Changed

- `Py4GWCoreLib/item_mods_src/item_mod.py`
  - rewrote `ItemMod.get_upgrade` matching flow
  - added explicit semantic upgrade-type matching
  - added exact comparison-data matching for instance lookups
  - removed the inconsistent nested branch behavior

- `Py4GWCoreLib/item_mods_src/upgrades.py`
  - updated upgrade equality/matching to be compatible with semantic upgrade comparisons across reload/import boundaries

- `Py4GWCoreLib/Item.py`
  - kept the wrapper aligned with the typed `get_upgrade` flow

- `Py4GWCoreLib/item_mods_src/_typing.py`
  - centralized shared upgrade generic typing (`TUpgrade`)